### PR TITLE
Add AvoidSingleUseComponents cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,6 +1,13 @@
 AllCops:
   ViewComponentParentClasses: []
 
+ViewComponent/AvoidSingleUseComponents:
+  Description: 'Detect trivial components that may be better as partials.'
+  Enabled: true
+  VersionAdded: '0.3'
+  Severity: info
+  StyleGuide: 'https://viewcomponent.org/best_practices.html'
+
 ViewComponent/ComponentSuffix:
   Description: 'Enforce -Component suffix for ViewComponent classes.'
   Enabled: true

--- a/lib/rubocop/cop/view_component/avoid_single_use_components.rb
+++ b/lib/rubocop/cop/view_component/avoid_single_use_components.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module ViewComponent
+      # Detects ViewComponent classes that appear to be trivial and may not
+      # add value over a partial. Components with no methods beyond
+      # `initialize`, no slots, and minimal logic may be better as partials.
+      #
+      # @example
+      #   # bad
+      #   class SimpleWrapperComponent < ViewComponent::Base
+      #     def initialize(content)
+      #       @content = content
+      #     end
+      #   end
+      #
+      #   # good - has additional methods
+      #   class CardComponent < ViewComponent::Base
+      #     def initialize(title)
+      #       @title = title
+      #     end
+      #
+      #     private
+      #
+      #     def formatted_title
+      #       @title.upcase
+      #     end
+      #   end
+      #
+      #   # good - has slots
+      #   class ModalComponent < ViewComponent::Base
+      #     renders_one :header
+      #     renders_many :actions
+      #
+      #     def initialize(title:)
+      #       @title = title
+      #     end
+      #   end
+      #
+      class AvoidSingleUseComponents < RuboCop::Cop::Base
+        include ViewComponent::Base
+
+        MSG = "This component appears to be trivial. Consider whether " \
+              "a partial would be simpler."
+
+        SLOT_METHODS = %i[renders_one renders_many].freeze
+
+        RESTRICT_ON_SEND = SLOT_METHODS
+
+        def on_class(node)
+          return unless view_component_class?(node)
+
+          body = node.body
+          return add_offense(node.identifier) unless body
+
+          children = body.begin_type? ? body.children : [body]
+
+          return if has_slots?(children)
+          return if has_non_initialize_methods?(children)
+
+          add_offense(node.identifier)
+        end
+
+        private
+
+        def has_slots?(children)
+          children.any? do |child|
+            child.send_type? && SLOT_METHODS.include?(child.method_name)
+          end
+        end
+
+        def has_non_initialize_methods?(children)
+          children.any? do |child|
+            next false unless child.def_type?
+
+            child.method_name != :initialize
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/view_component_cops.rb
+++ b/lib/rubocop/cop/view_component_cops.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "view_component/base"
+require_relative "view_component/avoid_single_use_components"
 require_relative "view_component/component_suffix"
 require_relative "view_component/no_global_state"
 require_relative "view_component/prefer_private_methods"

--- a/spec/rubocop/cop/view_component/avoid_single_use_components_spec.rb
+++ b/spec/rubocop/cop/view_component/avoid_single_use_components_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::ViewComponent::AvoidSingleUseComponents, :config do
+  let(:config) { RuboCop::Config.new }
+
+  context "when component has only initialize" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        class SimpleWrapperComponent < ViewComponent::Base
+              ^^^^^^^^^^^^^^^^^^^^^^ ViewComponent/AvoidSingleUseComponents: This component appears to be trivial. Consider whether a partial would be simpler.
+          def initialize(content)
+            @content = content
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when component has an empty body" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        class EmptyComponent < ViewComponent::Base
+              ^^^^^^^^^^^^^^ ViewComponent/AvoidSingleUseComponents: This component appears to be trivial. Consider whether a partial would be simpler.
+        end
+      RUBY
+    end
+  end
+
+  context "when component has additional methods" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        class CardComponent < ViewComponent::Base
+          def initialize(title)
+            @title = title
+          end
+
+          def formatted_title
+            @title.upcase
+          end
+        end
+      RUBY
+    end
+
+    it "does not register an offense for private methods" do
+      expect_no_offenses(<<~RUBY)
+        class CardComponent < ViewComponent::Base
+          def initialize(title)
+            @title = title
+          end
+
+          private
+
+          def formatted_title
+            @title.upcase
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when component has slots" do
+    it "does not register an offense with renders_one" do
+      expect_no_offenses(<<~RUBY)
+        class ModalComponent < ViewComponent::Base
+          renders_one :header
+
+          def initialize(title:)
+            @title = title
+          end
+        end
+      RUBY
+    end
+
+    it "does not register an offense with renders_many" do
+      expect_no_offenses(<<~RUBY)
+        class ListComponent < ViewComponent::Base
+          renders_many :items
+
+          def initialize(title:)
+            @title = title
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when not a ViewComponent" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        class SimpleClass < ActiveRecord::Base
+          def initialize(name)
+            @name = name
+          end
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `ViewComponent/AvoidSingleUseComponents` cop that flags trivial components with no methods beyond `initialize` and no slots
- Uses `info` severity since this is advisory — suggests considering a partial instead
- Based on the [ViewComponent best practice](https://viewcomponent.org/best_practices.html) to minimize one-offs

## Test plan
- [x] Registers offense for components with only `initialize`
- [x] Registers offense for empty component bodies
- [x] Allows components with additional methods (public or private)
- [x] Allows components with `renders_one` or `renders_many` slots
- [x] Ignores non-ViewComponent classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)