### PR TITLE
Improve primer verification script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,4 +41,4 @@ jobs:
           ruby-version: '3.4.7'
           bundler-cache: true
       - name: Verify against Primer ViewComponents
-        run: bundle exec ruby script/verify_against_primer.rb
+        run: script/verify_against_primer

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/verification/primer/

--- a/README.md
+++ b/README.md
@@ -72,18 +72,24 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Primer Verification
 
-The cops are tested against [primer/view_components](https://github.com/primer/view_components) as a real-world baseline, and to catch regressions. The script [`verify_against_primer.rb`](script/verify_against_primer.rb) copies the Primer repo, runs all ViewComponent cops against it, and compares the results to a checked-in snapshot ([`expected_primer_failures.json`](spec/expected_primer_failures.json)). This runs automatically in CI.
+The cops are tested against [primer/view_components](https://github.com/primer/view_components) as a real-world baseline, and to catch regressions. The script [`verify_against_primer`](script/verify_against_primer) downloads the Primer repo (cached in `verification/primer/`), runs all ViewComponent cops against it, and compares the results to a checked-in snapshot ([`expected_primer_failures.json`](spec/expected_primer_failures.json)). This runs automatically in CI.
 
 To verify locally:
 
 ```bash
-bundle exec ruby script/verify_against_primer.rb
+script/verify_against_primer
 ```
 
 If you intentionally change cop behavior, regenerate the snapshot:
 
 ```bash
-bundle exec ruby script/verify_against_primer.rb --regenerate
+script/verify_against_primer --regenerate
+```
+
+To force download the latest Primer source:
+
+```bash
+script/verify_against_primer --update
 ```
 
 ## Contributing

--- a/script/verify_against_primer
+++ b/script/verify_against_primer
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require "json"
@@ -10,25 +11,35 @@ require "bundler"
 GEM_DIR = File.expand_path("..", __dir__)
 RESULTS_FILE = File.join(GEM_DIR, "spec", "expected_primer_failures.json")
 TARBALL_URL = "https://github.com/primer/view_components/archive/refs/heads/main.tar.gz"
+VERIFICATION_DIR = File.join(GEM_DIR, "verification", "primer")
 
 def main
   mode = ARGV.include?("--regenerate") ? :regenerate : :verify
+  force_update = ARGV.include?("--update")
 
-  Dir.mktmpdir do |dir|
-    download_source(dir)
+  if force_update && Dir.exist?(VERIFICATION_DIR)
+    puts "Removing existing primer source for update..."
+    FileUtils.rm_rf(VERIFICATION_DIR)
+  end
 
-    Dir.chdir(dir) do
-      configure_rubocop
-      add_gem_to_gemfile
+  if Dir.exist?(VERIFICATION_DIR) && !Dir.empty?(VERIFICATION_DIR)
+    puts "Using existing primer source at #{VERIFICATION_DIR}"
+  else
+    FileUtils.mkdir_p(VERIFICATION_DIR)
+    download_source(VERIFICATION_DIR)
+  end
 
-      Bundler.with_unbundled_env do
-        output = run_rubocop
-        offenses = extract_offenses(output)
+  Dir.chdir(VERIFICATION_DIR) do
+    configure_rubocop
+    add_gem_to_gemfile
 
-        case mode
-        when :regenerate then regenerate(offenses)
-        when :verify then verify(offenses)
-        end
+    Bundler.with_unbundled_env do
+      output = run_rubocop
+      offenses = extract_offenses(output)
+
+      case mode
+      when :regenerate then regenerate(offenses)
+      when :verify then verify(offenses)
       end
     end
   end


### PR DESCRIPTION
## Summary
- Converts verification script to executable (removes .rb extension, adds shebang)
- Caches primer downloads in `verification/primer/` to avoid repeated downloads
- Adds `--update` flag to force fresh download when needed
- Updates README and CI workflow to use new script name

## Benefits
- Faster verification runs (no re-download unless --update is used)
- Simpler command: `script/verify_against_primer` instead of `bundle exec ruby script/verify_against_primer.rb`
- Cached source for debugging and inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)