### PR TITLE
Add ViewComponent rationale comment to NoGlobalState cop

### DIFF
--- a/lib/rubocop/cop/view_component/no_global_state.rb
+++ b/lib/rubocop/cop/view_component/no_global_state.rb
@@ -5,6 +5,11 @@ module RuboCop
     module ViewComponent
       # Prevents direct access to global state within ViewComponent classes.
       #
+      # ViewComponent's own documentation notes that accessing `request` directly
+      # "introduces coupling that inhibits encapsulation & reuse, often making
+      # testing difficult." The same principle applies to `params`, `session`,
+      # `cookies`, and `flash`.
+      #
       # @example
       #   # bad
       #   class UserComponent < ViewComponent::Base


### PR DESCRIPTION
> [!NOTE]
> This PR was co-authored with [Claude Code](https://claude.com/claude-code). I have carefully verified it.

## Summary

- Adds a comment to `NoGlobalState` referencing ViewComponent's own documentation, which warns that accessing `request` directly "introduces coupling that inhibits encapsulation & reuse, often making testing difficult."
- Extends the rationale to cover the other global state methods the cop detects (`params`, `session`, `cookies`, `flash`).

## Test plan

- [ ] No behaviour change — documentation only