### PR TITLE
Add TestPaths parameter to TestRenderedOutput cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -55,3 +55,4 @@ ViewComponent/TestRenderedOutput:
   Include:
     - 'spec/components/**/*_spec.rb'
     - 'test/components/**/*_test.rb'
+  TestPaths: []

--- a/lib/rubocop/cop/view_component/test_rendered_output.rb
+++ b/lib/rubocop/cop/view_component/test_rendered_output.rb
@@ -27,6 +27,7 @@ module RuboCop
 
         # Check Minitest-style test methods
         def on_def(node)
+          return unless within_test_paths?
           method_name = node.method_name.to_s
           return unless method_name.start_with?("test_")
           return unless instantiates_component?(node)
@@ -37,6 +38,7 @@ module RuboCop
 
         # Check RSpec-style it blocks
         def on_block(node)
+          return unless within_test_paths?
           return unless rspec_it_block?(node)
           return unless instantiates_component?(node)
           return if contains_render_method?(node)
@@ -45,6 +47,14 @@ module RuboCop
         end
 
         private
+
+        def within_test_paths?
+          test_paths = cop_config["TestPaths"]
+          return true if test_paths.nil? || test_paths.empty?
+
+          file_path = processed_source.path
+          test_paths.any? { |path| file_path.include?(path) }
+        end
 
         def instantiates_component?(node)
           node.each_descendant(:send).any? do |send_node|

--- a/spec/rubocop/cop/view_component/test_rendered_output_spec.rb
+++ b/spec/rubocop/cop/view_component/test_rendered_output_spec.rb
@@ -96,6 +96,40 @@ RSpec.describe RuboCop::Cop::ViewComponent::TestRenderedOutput, :config do
     end
   end
 
+  context "with TestPaths configured" do
+    let(:config) do
+      RuboCop::Config.new(
+        "AllCops" => {"DisplayCopNames" => true},
+        "ViewComponent/TestRenderedOutput" => {
+          "TestPaths" => ["spec/components/v2/"]
+        }
+      )
+    end
+
+    context "when file is within a configured TestPath" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY, "spec/components/v2/button_component_spec.rb")
+          def test_formatted_title
+          ^^^^^^^^^^^^^^^^^^^^^^^^ ViewComponent/TestRenderedOutput: Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly.
+            component = UserComponent.new("hello")
+            assert_equal "HELLO", component.formatted_title
+          end
+        RUBY
+      end
+    end
+
+    context "when file is outside all configured TestPaths" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY, "spec/components/v1/button_component_spec.rb")
+          def test_formatted_title
+            component = UserComponent.new("hello")
+            assert_equal "HELLO", component.formatted_title
+          end
+        RUBY
+      end
+    end
+  end
+
   context "with RSpec-style tests" do
     context "when it block instantiates a component but doesn't render" do
       it "registers an offense" do


### PR DESCRIPTION
> [!NOTE]
> This PR was co-authored with [Claude Code](https://claude.com/claude-code). I have carefully verified it.

## Summary

- Adds a `TestPaths` configuration parameter to `ViewComponent/TestRenderedOutput`
- When `TestPaths` is set, the cop only reports offenses for files whose path matches one of the configured paths
- When `TestPaths` is empty (the default), the cop runs on all `Include`-matched files as before

This enables incremental rollout — users can scope the cop to a subset of their test files without needing fragile `Exclude` entries for everything else.

Closes #20

## Usage

```yaml
ViewComponent/TestRenderedOutput:
  Enabled: true
  TestPaths:
    - "spec/components/v2/"
```

## Test plan

- [ ] Existing tests still pass (no regressions)
- [ ] New test: file within a configured `TestPaths` entry registers an offense
- [ ] New test: file outside all configured `TestPaths` entries does not register an offense