### PR TITLE
Use rubocop_todo.yml-style format for expected failures files

### DIFF
--- a/script/verify
+++ b/script/verify
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "set"
 require "yaml"
 require "tmpdir"
 require "fileutils"
@@ -134,18 +135,15 @@ end
 
 def extract_offenses(rubocop_output)
   data = JSON.parse(rubocop_output)
-  offenses_by_cop = Hash.new { |h, k| h[k] = [] }
+  offenses_by_cop = Hash.new { |h, k| h[k] = Set.new }
 
   data["files"].each do |file|
     file["offenses"].each do |offense|
-      offenses_by_cop[offense["cop_name"]] << {
-        location: "#{file["path"]}:#{offense["location"]["start_line"]}",
-        message: offense["message"]
-      }
+      offenses_by_cop[offense["cop_name"]] << file["path"]
     end
   end
 
-  offenses_by_cop.transform_values { |os| os.sort_by { |o| o[:location] } }.sort.to_h
+  offenses_by_cop.transform_values { |paths| paths.sort }.sort.to_h
 end
 
 def regenerate(offenses, results_file)
@@ -154,18 +152,18 @@ def regenerate(offenses, results_file)
   lines << "# It captures known offenses in the library source."
   lines << "---"
 
-  offenses.each do |cop, entries|
+  offenses.each do |cop, paths|
     lines << "#{cop}:"
-    entries.each { |e| lines << "  - #{e[:location]} # #{e[:message]}" }
+    lines << "  Exclude:"
+    paths.each { |path| lines << "    - '#{path}'" }
   end
 
   File.write(results_file, lines.join("\n") + "\n")
   total = offenses.values.sum(&:length)
-  puts "#{total} offense(s) written to #{results_file}"
+  puts "#{total} file(s) with offense(s) written to #{results_file}"
 end
 
 def load_expected(results_file)
-  # YAML strips inline comments, so each entry loads as just the location string
   YAML.load_file(results_file)
 end
 
@@ -174,20 +172,19 @@ def verify(offenses, results_file)
     abort "ERROR: #{results_file} not found. Run '#{$PROGRAM_NAME} --regenerate' first."
   end
 
-  expected = load_expected(results_file)
-  current = offenses.transform_values { |os| os.map { |o| o[:location] } }
+  expected = load_expected(results_file).transform_values { |v| v["Exclude"] }
 
-  if current == expected
+  if offenses == expected
     puts "Verification passed: output matches #{results_file}"
   else
     puts "Verification failed: output differs from #{results_file}"
 
-    all_cops = (current.keys + expected.keys).uniq.sort
+    all_cops = (offenses.keys + expected.keys).uniq.sort
     all_cops.each do |cop|
-      added = (current[cop] || []) - (expected[cop] || [])
-      removed = (expected[cop] || []) - (current[cop] || [])
-      added.each { |loc| puts "  + #{cop}: #{loc}" }
-      removed.each { |loc| puts "  - #{cop}: #{loc}" }
+      added = (offenses[cop] || []) - (expected[cop] || [])
+      removed = (expected[cop] || []) - (offenses[cop] || [])
+      added.each { |path| puts "  + #{cop}: #{path}" }
+      removed.each { |path| puts "  - #{cop}: #{path}" }
     end
 
     exit 1

--- a/script/verify
+++ b/script/verify
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "json"
-require "set"
 require "yaml"
 require "tmpdir"
 require "fileutils"

--- a/spec/expected_govuk_failures.yml
+++ b/spec/expected_govuk_failures.yml
@@ -2,38 +2,26 @@
 # It captures known offenses in the library source.
 ---
 ViewComponent/ComponentSuffix:
-  - app/components/govuk_component/base.rb:1 # ViewComponent class names should end with `Component`. (https://viewcomponent.org/best_practices.html)
-  - app/components/govuk_component/header_component.rb:46 # ViewComponent class names should end with `Component`. (https://viewcomponent.org/best_practices.html)
-  - app/components/govuk_component/notification_banner_component.rb:33 # ViewComponent class names should end with `Component`. (https://viewcomponent.org/best_practices.html)
-  - app/components/govuk_component/pagination_component/adjacent_page.rb:1 # ViewComponent class names should end with `Component`. (https://viewcomponent.org/best_practices.html)
-  - app/components/govuk_component/pagination_component/item.rb:1 # ViewComponent class names should end with `Component`. (https://viewcomponent.org/best_practices.html)
-  - app/components/govuk_component/tab_component.rb:21 # ViewComponent class names should end with `Component`. (https://viewcomponent.org/best_practices.html)
+  Exclude:
+    - 'app/components/govuk_component/base.rb'
+    - 'app/components/govuk_component/header_component.rb'
+    - 'app/components/govuk_component/notification_banner_component.rb'
+    - 'app/components/govuk_component/pagination_component/adjacent_page.rb'
+    - 'app/components/govuk_component/pagination_component/item.rb'
+    - 'app/components/govuk_component/tab_component.rb'
 ViewComponent/PreferPrivateMethods:
-  - app/components/govuk_component/base.rb:29 # Consider making `brand` private. Only ViewComponent interface methods should be public. (https://viewcomponent.org/best_practices.html)
-  - app/components/govuk_component/base.rb:35 # Consider making `class_prefix` private. Only ViewComponent interface methods should be public. (https://viewcomponent.org/best_practices.html)
-  - app/components/govuk_component/notification_banner_component.rb:55 # Consider making `link` private. Only ViewComponent interface methods should be public. (https://viewcomponent.org/best_practices.html)
-  - app/components/govuk_component/notification_banner_component.rb:59 # Consider making `default_attributes` private. Only ViewComponent interface methods should be public. (https://viewcomponent.org/best_practices.html)
-  - app/components/govuk_component/service_navigation_component.rb:54 # Consider making `navigation` private. Only ViewComponent interface methods should be public. (https://viewcomponent.org/best_practices.html)
-  - app/components/govuk_component/service_navigation_component.rb:62 # Consider making `navigation_list` private. Only ViewComponent interface methods should be public. (https://viewcomponent.org/best_practices.html)
-  - app/components/govuk_component/tab_component.rb:32 # Consider making `hidden_class` private. Only ViewComponent interface methods should be public. (https://viewcomponent.org/best_practices.html)
-  - app/components/govuk_component/tab_component.rb:38 # Consider making `li_classes` private. Only ViewComponent interface methods should be public. (https://viewcomponent.org/best_practices.html)
-  - app/components/govuk_component/tab_component.rb:42 # Consider making `li_link` private. Only ViewComponent interface methods should be public. (https://viewcomponent.org/best_practices.html)
-  - app/components/govuk_component/tab_component.rb:46 # Consider making `default_attributes` private. Only ViewComponent interface methods should be public. (https://viewcomponent.org/best_practices.html)
-  - app/components/govuk_component/tab_component.rb:50 # Consider making `combined_attributes` private. Only ViewComponent interface methods should be public. (https://viewcomponent.org/best_practices.html)
+  Exclude:
+    - 'app/components/govuk_component/base.rb'
+    - 'app/components/govuk_component/notification_banner_component.rb'
+    - 'app/components/govuk_component/service_navigation_component.rb'
+    - 'app/components/govuk_component/tab_component.rb'
 ViewComponent/TestRenderedOutput:
-  - spec/components/govuk_component/accordion_component_spec.rb:84 # Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly. (https://viewcomponent.org/guide/testing.html)
-  - spec/components/govuk_component/breadcrumbs_component_spec.rb:44 # Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly. (https://viewcomponent.org/guide/testing.html)
-  - spec/components/govuk_component/configuration/footer_component_configuration_spec.rb:42 # Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly. (https://viewcomponent.org/guide/testing.html)
-  - spec/components/govuk_component/footer_component_spec.rb:123 # Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly. (https://viewcomponent.org/guide/testing.html)
-  - spec/components/govuk_component/footer_component_spec.rb:182 # Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly. (https://viewcomponent.org/guide/testing.html)
-  - spec/components/govuk_component/footer_component_spec.rb:235 # Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly. (https://viewcomponent.org/guide/testing.html)
-  - spec/components/govuk_component/footer_component_spec.rb:254 # Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly. (https://viewcomponent.org/guide/testing.html)
-  - spec/components/govuk_component/footer_component_spec.rb:274 # Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly. (https://viewcomponent.org/guide/testing.html)
-  - spec/components/govuk_component/footer_component_spec.rb:294 # Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly. (https://viewcomponent.org/guide/testing.html)
-  - spec/components/govuk_component/footer_component_spec.rb:312 # Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly. (https://viewcomponent.org/guide/testing.html)
-  - spec/components/govuk_component/footer_component_spec.rb:336 # Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly. (https://viewcomponent.org/guide/testing.html)
-  - spec/components/govuk_component/notification_banner_component_spec.rb:59 # Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly. (https://viewcomponent.org/guide/testing.html)
-  - spec/components/govuk_component/pagination_component_spec.rb:317 # Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly. (https://viewcomponent.org/guide/testing.html)
-  - spec/components/govuk_component/task_list_component_spec.rb:139 # Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly. (https://viewcomponent.org/guide/testing.html)
-  - spec/components/govuk_component/warning_text_component_spec.rb:11 # Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly. (https://viewcomponent.org/guide/testing.html)
-  - spec/components/govuk_component/warning_text_component_spec.rb:41 # Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly. (https://viewcomponent.org/guide/testing.html)
+  Exclude:
+    - 'spec/components/govuk_component/accordion_component_spec.rb'
+    - 'spec/components/govuk_component/breadcrumbs_component_spec.rb'
+    - 'spec/components/govuk_component/configuration/footer_component_configuration_spec.rb'
+    - 'spec/components/govuk_component/footer_component_spec.rb'
+    - 'spec/components/govuk_component/notification_banner_component_spec.rb'
+    - 'spec/components/govuk_component/pagination_component_spec.rb'
+    - 'spec/components/govuk_component/task_list_component_spec.rb'
+    - 'spec/components/govuk_component/warning_text_component_spec.rb'

--- a/spec/expected_polaris_failures.yml
+++ b/spec/expected_polaris_failures.yml
@@ -2,64 +2,57 @@
 # It captures known offenses in the library source.
 ---
 ViewComponent/ComponentSuffix:
-  - app/components/polaris/base_button.rb:4 # ViewComponent class names should end with `Component`.
-  - app/components/polaris/base_checkbox.rb:2 # ViewComponent class names should end with `Component`.
-  - app/components/polaris/base_radio_button.rb:2 # ViewComponent class names should end with `Component`.
-  - app/components/polaris/headless_button.rb:4 # ViewComponent class names should end with `Component`.
-  - app/components/polaris/layout/annotated_section.rb:5 # ViewComponent class names should end with `Component`.
-  - app/components/polaris/layout/section.rb:5 # ViewComponent class names should end with `Component`.
-  - app/components/polaris/text_field_component.rb:195 # ViewComponent class names should end with `Component`.
+  Exclude:
+    - 'app/components/polaris/base_button.rb'
+    - 'app/components/polaris/base_checkbox.rb'
+    - 'app/components/polaris/base_radio_button.rb'
+    - 'app/components/polaris/headless_button.rb'
+    - 'app/components/polaris/layout/annotated_section.rb'
+    - 'app/components/polaris/layout/section.rb'
+    - 'app/components/polaris/text_field_component.rb'
 ViewComponent/NoGlobalState:
-  - app/components/polaris/shopify_navigation_component.rb:59 # Avoid accessing `request` directly in ViewComponents. Pass necessary data through the constructor instead.
+  Exclude:
+    - 'app/components/polaris/shopify_navigation_component.rb'
 ViewComponent/PreferPrivateMethods:
-  - app/components/polaris/action_list/section_component.rb:16 # Consider making `system_arguments` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/avatar_component.rb:43 # Consider making `style_class` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/avatar_component.rb:69 # Consider making `xor_hash` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/banner_component.rb:77 # Consider making `default_icon` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/base_checkbox.rb:24 # Consider making `system_arguments` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/base_checkbox.rb:40 # Consider making `indeterminate?` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/base_radio_button.rb:21 # Consider making `system_arguments` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/button_group_component.rb:60 # Consider making `all_items` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/checkbox_component.rb:62 # Consider making `indeterminate?` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/choice_list_component.rb:58 # Consider making `renders?` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/choice_list_component.rb:62 # Consider making `multiple_choice_allowed?` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/collapsible_component.rb:15 # Consider making `system_arguments` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/description_list_component.rb:24 # Consider making `renders?` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/dropzone_component.rb:142 # Consider making `drop_actions` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/exception_list_component.rb:16 # Consider making `renders?` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/filters_component.rb:74 # Consider making `popover_arguments` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/form_layout_component.rb:29 # Consider making `all_items` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/headless_button.rb:104 # Consider making `html_options` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/headless_button.rb:96 # Consider making `system_arguments` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/index_table/cell_component.rb:7 # Consider making `system_arguments` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/inline_error_component.rb:14 # Consider making `renders?` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/keyboard_key_component.rb:9 # Consider making `system_arguments` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/label_component.rb:32 # Consider making `renders?` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/layout_component.rb:38 # Consider making `all_sections` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/modal/section_component.rb:6 # Consider making `system_arguments` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/navigation/item_component.rb:54 # Consider making `item_inner_wrapper_classes` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/navigation/item_component.rb:62 # Consider making `link_classes` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/navigation/item_component.rb:71 # Consider making `selected_sub_items?` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/navigation_component.rb:11 # Consider making `renders?` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/navigation_list_component.rb:9 # Consider making `renders?` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/new_tabs_component.rb:33 # Consider making `renders?` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/option_list/checkbox_component.rb:25 # Consider making `system_arguments` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/option_list/option_component.rb:6 # Consider making `system_arguments` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/option_list/radio_button_component.rb:32 # Consider making `system_arguments` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/option_list/section_component.rb:42 # Consider making `system_arguments` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/page_component.rb:57 # Consider making `title_length` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/popover/section_component.rb:6 # Consider making `system_arguments` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/popover_component.rb:112 # Consider making `popover_placement` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/resource_item/shortcut_actions_component.rb:82 # Consider making `action_list_item_arguments` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/resource_list_component.rb:37 # Consider making `resource_string` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/resource_list_component.rb:43 # Consider making `count` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/select_component.rb:88 # Consider making `hides_label?` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/shopify_navigation_component.rb:40 # Consider making `system_arguments` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/shopify_navigation_component.rb:56 # Consider making `detect_active` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/skeleton_display_text_component.rb:17 # Consider making `system_arguments` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/skeleton_thumbnail_component.rb:16 # Consider making `system_arguments` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/tabs_component.rb:33 # Consider making `renders?` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/text_component.rb:114 # Consider making `alignment_class` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/text_component.rb:120 # Consider making `color_class` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/text_component.rb:126 # Consider making `font_weight_class` private. Only ViewComponent interface methods should be public.
-  - app/components/polaris/thumbnail_component.rb:39 # Consider making `renders?` private. Only ViewComponent interface methods should be public.
+  Exclude:
+    - 'app/components/polaris/action_list/section_component.rb'
+    - 'app/components/polaris/avatar_component.rb'
+    - 'app/components/polaris/banner_component.rb'
+    - 'app/components/polaris/base_checkbox.rb'
+    - 'app/components/polaris/base_radio_button.rb'
+    - 'app/components/polaris/button_group_component.rb'
+    - 'app/components/polaris/checkbox_component.rb'
+    - 'app/components/polaris/choice_list_component.rb'
+    - 'app/components/polaris/collapsible_component.rb'
+    - 'app/components/polaris/description_list_component.rb'
+    - 'app/components/polaris/dropzone_component.rb'
+    - 'app/components/polaris/exception_list_component.rb'
+    - 'app/components/polaris/filters_component.rb'
+    - 'app/components/polaris/form_layout_component.rb'
+    - 'app/components/polaris/headless_button.rb'
+    - 'app/components/polaris/index_table/cell_component.rb'
+    - 'app/components/polaris/inline_error_component.rb'
+    - 'app/components/polaris/keyboard_key_component.rb'
+    - 'app/components/polaris/label_component.rb'
+    - 'app/components/polaris/layout_component.rb'
+    - 'app/components/polaris/modal/section_component.rb'
+    - 'app/components/polaris/navigation/item_component.rb'
+    - 'app/components/polaris/navigation_component.rb'
+    - 'app/components/polaris/navigation_list_component.rb'
+    - 'app/components/polaris/new_tabs_component.rb'
+    - 'app/components/polaris/option_list/checkbox_component.rb'
+    - 'app/components/polaris/option_list/option_component.rb'
+    - 'app/components/polaris/option_list/radio_button_component.rb'
+    - 'app/components/polaris/option_list/section_component.rb'
+    - 'app/components/polaris/page_component.rb'
+    - 'app/components/polaris/popover/section_component.rb'
+    - 'app/components/polaris/popover_component.rb'
+    - 'app/components/polaris/resource_item/shortcut_actions_component.rb'
+    - 'app/components/polaris/resource_list_component.rb'
+    - 'app/components/polaris/select_component.rb'
+    - 'app/components/polaris/shopify_navigation_component.rb'
+    - 'app/components/polaris/skeleton_display_text_component.rb'
+    - 'app/components/polaris/skeleton_thumbnail_component.rb'
+    - 'app/components/polaris/tabs_component.rb'
+    - 'app/components/polaris/text_component.rb'
+    - 'app/components/polaris/thumbnail_component.rb'

--- a/spec/expected_primer_failures.yml
+++ b/spec/expected_primer_failures.yml
@@ -2,26 +2,16 @@
 # It captures known offenses in the library source.
 ---
 ViewComponent/PreferPrivateMethods:
-  - app/components/primer/alpha/action_list.rb:189 # Consider making `build_item` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/alpha/action_list.rb:217 # Consider making `build_avatar_item` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/alpha/action_list.rb:228 # Consider making `single_select?` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/alpha/action_list.rb:236 # Consider making `allows_selection?` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/alpha/action_list.rb:240 # Consider making `acts_as_listbox?` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/alpha/action_list.rb:244 # Consider making `acts_as_menu?` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/alpha/action_list.rb:248 # Consider making `required_form_arguments_given?` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/alpha/action_list.rb:257 # Consider making `will_add_item` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/alpha/action_list.rb:53 # Consider making `custom_element_name` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/alpha/action_list/divider.rb:33 # Consider making `active?` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/alpha/action_list/form_wrapper.rb:53 # Consider making `get?` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/alpha/dropdown/menu.rb:96 # Consider making `divider?` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/alpha/form_control.rb:101 # Consider making `visually_hide_label?` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/alpha/form_control.rb:107 # Consider making `full_width?` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/alpha/toggle_switch.rb:94 # Consider making `on?` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/alpha/toggle_switch.rb:98 # Consider making `enabled?` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/alpha/tree_view/node.rb:155 # Consider making `merge_system_arguments!` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/beta/avatar.rb:22 # Consider making `link?` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/beta/nav_list.rb:116 # Consider making `build_item` private. Only ViewComponent interface methods should be public.
-  - app/components/primer/beta/nav_list.rb:139 # Consider making `build_avatar_item` private. Only ViewComponent interface methods should be public.
+  Exclude:
+    - 'app/components/primer/alpha/action_list.rb'
+    - 'app/components/primer/alpha/action_list/divider.rb'
+    - 'app/components/primer/alpha/action_list/form_wrapper.rb'
+    - 'app/components/primer/alpha/dropdown/menu.rb'
+    - 'app/components/primer/alpha/form_control.rb'
+    - 'app/components/primer/alpha/toggle_switch.rb'
+    - 'app/components/primer/alpha/tree_view/node.rb'
+    - 'app/components/primer/beta/avatar.rb'
+    - 'app/components/primer/beta/nav_list.rb'
 ViewComponent/TestRenderedOutput:
-  - test/components/alpha/action_list_test.rb:253 # Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly.
-  - test/components/alpha/action_list_test.rb:268 # Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly.
+  Exclude:
+    - 'test/components/alpha/action_list_test.rb'


### PR DESCRIPTION
> [!NOTE]
> This PR was co-authored with [Claude Code](https://claude.com/claude-code). I have carefully verified it.

## Summary

- Replaces per-offense entries (with line numbers and messages) with per-file `Exclude:` lists under each cop name
- Matches the familiar structure of `.rubocop_todo.yml`
- Updates `script/verify` to extract and compare file paths only (deduplicating multiple offenses per file)

## Trade-offs

Line numbers and offense messages are no longer stored in the expected files. The files become significantly more concise and readable at the cost of that detail.

## Test plan

- [ ] Run `script/verify primer` and confirm it passes
- [ ] Run `script/verify govuk` and confirm it passes
- [ ] Run `script/verify polaris` and confirm it passes
- [ ] Run `script/verify primer --regenerate` and confirm the output matches the checked-in file