### PR TITLE
Add ComponentNamespaces config option to PreferComposition cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -37,7 +37,7 @@ ViewComponent/PreferComposition:
   Enabled: true
   VersionAdded: '0.3'
   Severity: convention
-  StyleGuide: 'https://viewcomponent.org/best_practices.html'
+  StyleGuide: 'https://viewcomponent.org/best_practices.html#avoid-inheritance'
   ComponentNamespaces: []
 
 ViewComponent/PreferSlots:

--- a/config/default.yml
+++ b/config/default.yml
@@ -38,6 +38,7 @@ ViewComponent/PreferComposition:
   VersionAdded: '0.3'
   Severity: convention
   StyleGuide: 'https://viewcomponent.org/best_practices.html'
+  ComponentNamespaces: []
 
 ViewComponent/PreferSlots:
   Description: 'Prefer slots over HTML string parameters.'

--- a/lib/rubocop/cop/view_component/prefer_composition.rb
+++ b/lib/rubocop/cop/view_component/prefer_composition.rb
@@ -36,7 +36,13 @@ module RuboCop
         def component_like_parent?(node)
           return false unless node.const_type?
 
-          node.source.end_with?("Component")
+          source = node.source
+          source.end_with?("Component") ||
+            component_namespaces.any? { |ns| source.start_with?(ns) }
+        end
+
+        def component_namespaces
+          cop_config.fetch("ComponentNamespaces", [])
         end
       end
     end

--- a/spec/rubocop/cop/view_component/prefer_composition_spec.rb
+++ b/spec/rubocop/cop/view_component/prefer_composition_spec.rb
@@ -64,6 +64,31 @@ RSpec.describe RuboCop::Cop::ViewComponent::PreferComposition, :config do
     end
   end
 
+  context "when ComponentNamespaces is configured" do
+    let(:config) do
+      RuboCop::Config.new(
+        "ViewComponent/PreferComposition" => {
+          "ComponentNamespaces" => ["V2::"]
+        }
+      )
+    end
+
+    it "registers an offense for a class in a configured namespace" do
+      expect_offense(<<~RUBY)
+        class UserCard < V2::Table
+                         ^^^^^^^^^ Avoid inheriting from another ViewComponent.
+        end
+      RUBY
+    end
+
+    it "does not register an offense for a class outside configured namespaces" do
+      expect_no_offenses(<<~RUBY)
+        class UserCard < SomeOtherBase
+        end
+      RUBY
+    end
+  end
+
   context "when ViewComponentParentClasses is configured" do
     let(:config) do
       RuboCop::Config.new(


### PR DESCRIPTION
> [!NOTE]
> This PR was co-authored with [Claude Code](https://claude.com/claude-code). I have carefully verified it.

## Summary

Closes #24

- Adds a `ComponentNamespaces` config option to `ViewComponent/PreferComposition`
- Parent classes whose source starts with a configured namespace prefix are now treated as component-like
- Default is an empty array, so existing behaviour is unchanged

## Usage

```yaml
ViewComponent/PreferComposition:
  ComponentNamespaces:
    - "V2::"
```

With this config, a class like `class UserCard < V2::Table` will be flagged.

## Test plan

- [x] New spec covers offense registered for a class in a configured namespace
- [x] New spec covers no offense for a class outside configured namespaces
- [x] All existing specs still pass (`bundle exec rake`)