### PR TITLE
Declare ComponentNamespaces in per-cop config to fix warnings

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -19,6 +19,7 @@ ViewComponent/MissingPreview:
   PreviewPaths:
     - test/components/previews
     - spec/components/previews
+  ComponentNamespaces: []
 
 ViewComponent/NoGlobalState:
   Description: 'Avoid accessing global state (params, request, session, cookies,
@@ -51,6 +52,7 @@ ViewComponent/PreferComposition:
   VersionAdded: '0.3'
   Severity: convention
   StyleGuide: 'https://viewcomponent.org/best_practices.html#avoid-inheritance'
+  ComponentNamespaces: []
 
 ViewComponent/PreferSlots:
   Description: 'Prefer slots over HTML string parameters.'


### PR DESCRIPTION
RuboCop validates parameters per-cop, not per-department. Although ComponentNamespaces was defined at the ViewComponent department level and read correctly at runtime, RuboCop emitted warnings because it wasn't declared under each cop that uses it.