### PR TITLE
Move ViewComponentParentClasses defaults into config/default.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,25 @@ This gem provides several cops to enforce ViewComponent best practices:
 
 ### Base Class
 
-By default, the cops detect classes that inherit from `ViewComponent::Base` or `ApplicationComponent`. If your project uses a different base class (e.g. `Primer::Component`), you can configure additional parent classes under `AllCops`, for example:
+By default, the cops detect classes that inherit from `ViewComponent::Base` or `ApplicationComponent`. To add extra parent classes, use `inherit_mode: merge` so the defaults are preserved:
 
 ```yaml
 # .rubocop.yml
-AllCops:
+ViewComponent:
+  inherit_mode:
+    merge:
+      - ViewComponentParentClasses
   ViewComponentParentClasses:
+    - MyApp::BaseComponent
+```
+
+To replace the defaults entirely (e.g. if your project has renamed `ApplicationComponent`), omit `inherit_mode`:
+
+```yaml
+# .rubocop.yml
+ViewComponent:
+  ViewComponentParentClasses:
+    - ViewComponent::Base
     - MyApp::BaseComponent
 ```
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,5 +1,7 @@
 ViewComponent:
-  ViewComponentParentClasses: []
+  ViewComponentParentClasses:
+    - ViewComponent::Base
+    - ApplicationComponent
   ComponentNamespaces: []
 
 ViewComponent/ComponentSuffix:

--- a/lib/rubocop/cop/view_component/base.rb
+++ b/lib/rubocop/cop/view_component/base.rb
@@ -18,16 +18,11 @@ module RuboCop
           view_component_parent?(parent_class)
         end
 
-        # Check if node represents ViewComponent::Base, ApplicationComponent,
-        # or a configured additional parent class
+        # Check if node represents a configured parent class
         def view_component_parent?(node)
           return false unless node.const_type?
 
-          source = node.source
-          return true if source == "ViewComponent::Base" || source == "ApplicationComponent"
-
-          additional = cop_config["ViewComponentParentClasses"] || []
-          additional.include?(source)
+          (cop_config["ViewComponentParentClasses"] || []).include?(node.source)
         end
 
         def component_namespaces

--- a/spec/rubocop/cop/view_component/component_suffix_spec.rb
+++ b/spec/rubocop/cop/view_component/component_suffix_spec.rb
@@ -74,11 +74,11 @@ RSpec.describe RuboCop::Cop::ViewComponent::ComponentSuffix, :config do
     end
   end
 
-  context "when ViewComponentParentClasses is configured" do
+  context "when ViewComponentParentClasses is configured with merge" do
     let(:config) do
       RuboCop::Config.new(
         "ViewComponent/ComponentSuffix" => {
-          "ViewComponentParentClasses" => ["Primer::Component"]
+          "ViewComponentParentClasses" => ["ViewComponent::Base", "ApplicationComponent", "Primer::Component"]
         }
       )
     end
@@ -102,6 +102,31 @@ RSpec.describe RuboCop::Cop::ViewComponent::ComponentSuffix, :config do
       expect_offense(<<~RUBY)
         class FooBar < ViewComponent::Base
               ^^^^^^ ViewComponent class names should end with `Component`.
+        end
+      RUBY
+    end
+  end
+
+  context "when ViewComponentParentClasses is configured replacing defaults" do
+    let(:config) do
+      RuboCop::Config.new(
+        "ViewComponent/ComponentSuffix" => {
+          "ViewComponentParentClasses" => ["Primer::Component"]
+        }
+      )
+    end
+
+    it "registers an offense for classes inheriting from a configured parent" do
+      expect_offense(<<~RUBY)
+        class FooBar < Primer::Component
+              ^^^^^^ ViewComponent class names should end with `Component`.
+        end
+      RUBY
+    end
+
+    it "does not recognize default parent classes that were replaced" do
+      expect_no_offenses(<<~RUBY)
+        class FooBar < ViewComponent::Base
         end
       RUBY
     end

--- a/spec/rubocop/cop/view_component/missing_preview_spec.rb
+++ b/spec/rubocop/cop/view_component/missing_preview_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe RuboCop::Cop::ViewComponent::MissingPreview, :config do
     RuboCop::Config.new(
       "ViewComponent/MissingPreview" => {
         "Enabled" => true,
-        "PreviewPaths" => ["/previews"]
+        "PreviewPaths" => ["/previews"],
+        "ViewComponentParentClasses" => %w[ViewComponent::Base ApplicationComponent]
       }
     )
   end

--- a/spec/rubocop/cop/view_component/prefer_private_methods_spec.rb
+++ b/spec/rubocop/cop/view_component/prefer_private_methods_spec.rb
@@ -147,7 +147,8 @@ RSpec.describe RuboCop::Cop::ViewComponent::PreferPrivateMethods, :config do
           "AllCops" => {"DisplayCopNames" => true},
           "ViewComponent/PreferPrivateMethods" => {
             "AllowedPublicMethods" => %w[initialize call],
-            "AllowedPublicMethodPatterns" => ["^render_", "^with_"]
+            "AllowedPublicMethodPatterns" => ["^render_", "^with_"],
+            "ViewComponentParentClasses" => %w[ViewComponent::Base ApplicationComponent]
           }
         )
       end
@@ -189,7 +190,8 @@ RSpec.describe RuboCop::Cop::ViewComponent::PreferPrivateMethods, :config do
         "AllCops" => {"DisplayCopNames" => true},
         "ViewComponent/PreferPrivateMethods" => {
           "AllowedPublicMethods" => %w[initialize call custom_public_method],
-          "AllowedPublicMethodPatterns" => []
+          "AllowedPublicMethodPatterns" => [],
+          "ViewComponentParentClasses" => %w[ViewComponent::Base ApplicationComponent]
         }
       )
     end

--- a/verification/govuk_rubocop_config.yml
+++ b/verification/govuk_rubocop_config.yml
@@ -1,4 +1,7 @@
 ViewComponent:
+  inherit_mode:
+    merge:
+      - ViewComponentParentClasses
   ViewComponentParentClasses:
     - GovukComponent::Base
 

--- a/verification/polaris_rubocop_config.yml
+++ b/verification/polaris_rubocop_config.yml
@@ -1,4 +1,7 @@
 ViewComponent:
+  inherit_mode:
+    merge:
+      - ViewComponentParentClasses
   ViewComponentParentClasses:
     - Polaris::Component
     - Component

--- a/verification/primer_rubocop_config.yml
+++ b/verification/primer_rubocop_config.yml
@@ -1,4 +1,7 @@
 ViewComponent:
+  inherit_mode:
+    merge:
+      - ViewComponentParentClasses
   ViewComponentParentClasses:
     - Primer::Component
     - Primer::BaseComponent


### PR DESCRIPTION
> [!NOTE]
> This PR was co-authored with [Claude Code](https://claude.com/claude-code). I have carefully verified it.

## Summary

Fixes #29.

- Moves the hardcoded `ViewComponent::Base` and `ApplicationComponent` entries from Ruby into `config/default.yml` so there is a single source of truth
- Simplifies `view_component_parent?` to just consult `cop_config["ViewComponentParentClasses"]`
- Updates specs that constructed partial configs to include the default parent classes explicitly (required now that defaults live in config rather than code)
- Adds a new spec context documenting the replace-defaults behaviour

## Behaviour changes

| Scenario | Before | After |
|---|---|---|
| Default config | `ViewComponent::Base` and `ApplicationComponent` recognised (hardcoded) | Same — they are in `config/default.yml` |
| `inherit_mode: merge` + custom class | Merges into empty default; builtins still recognised via code | Merges into the truthful default list; all classes recognised |
| Replace list (no merge) | Builtins still recognised via hardcoded check despite replacement | Builtins no longer recognised — replacement is honoured |
| `--show-cops` output | Shows empty `ViewComponentParentClasses: []` | Shows the actual defaults |

## Test plan

- [x] `bundle exec rake` — all 82 examples pass, linting clean