### PR TITLE
MissingPreview: exempt classes registered as ViewComponentParentClasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This gem provides several cops to enforce ViewComponent best practices:
 - **ViewComponent/PreferSlots** - Detect HTML parameters that should be slots
 - **ViewComponent/PreferComposition** - Avoid inheriting one ViewComponent from another (prefer composition)
 - **ViewComponent/TestRenderedOutput** - Encourage testing rendered output over private methods
-- **ViewComponent/MissingPreview** - Ensure every ViewComponent has a corresponding preview file (requires `PreviewPaths` configuration)
+- **ViewComponent/MissingPreview** - Ensure every ViewComponent has a corresponding preview file (requires `PreviewPaths` configuration). Classes listed in `ViewComponentParentClasses` are automatically exempt, as abstract base classes are not rendered standalone.
 
 ## Optional Configuration
 

--- a/lib/rubocop/cop/view_component/base.rb
+++ b/lib/rubocop/cop/view_component/base.rb
@@ -26,16 +26,18 @@ module RuboCop
         end
 
         # Check if a class node is itself one of the registered parent classes.
-        # Uses the fully-qualified name so namespaced parents (e.g. MyApp::BaseComponent)
-        # are matched correctly against the configured list.
         def view_component_parent_class?(node)
           return false unless node&.class_type?
 
-          fqn = node.parent_module_name
-          short = node.identifier.source
-          qualified = fqn.nil? || fqn == "Object" ? short : "#{fqn}::#{short}"
+          (cop_config["ViewComponentParentClasses"] || []).include?(fully_qualified_name(node))
+        end
 
-          (cop_config["ViewComponentParentClasses"] || []).include?(qualified)
+        def fully_qualified_name(node)
+          namespace = node.parent_module_name
+          short_name = node.identifier.source
+          return short_name if namespace.nil? || namespace == "Object"
+
+          "#{namespace}::#{short_name}"
         end
 
         def component_namespaces

--- a/lib/rubocop/cop/view_component/base.rb
+++ b/lib/rubocop/cop/view_component/base.rb
@@ -25,6 +25,19 @@ module RuboCop
           (cop_config["ViewComponentParentClasses"] || []).include?(node.source)
         end
 
+        # Check if a class node is itself one of the registered parent classes.
+        # Uses the fully-qualified name so namespaced parents (e.g. MyApp::BaseComponent)
+        # are matched correctly against the configured list.
+        def view_component_parent_class?(node)
+          return false unless node&.class_type?
+
+          fqn = node.parent_module_name
+          short = node.identifier.source
+          qualified = fqn.nil? || fqn == "Object" ? short : "#{fqn}::#{short}"
+
+          (cop_config["ViewComponentParentClasses"] || []).include?(qualified)
+        end
+
         def component_namespaces
           cop_config["ComponentNamespaces"] || []
         end

--- a/lib/rubocop/cop/view_component/missing_preview.rb
+++ b/lib/rubocop/cop/view_component/missing_preview.rb
@@ -27,14 +27,6 @@ module RuboCop
 
         private
 
-        def fully_qualified_name(node)
-          namespace = node.parent_module_name
-          short_name = node.identifier.source
-          return short_name if namespace.nil? || namespace == "Object"
-
-          "#{namespace}::#{short_name}"
-        end
-
         def preview_exists?(class_name)
           preview_paths.any? do |preview_path|
             candidate_filenames(class_name).any? do |filename|

--- a/lib/rubocop/cop/view_component/missing_preview.rb
+++ b/lib/rubocop/cop/view_component/missing_preview.rb
@@ -17,6 +17,7 @@ module RuboCop
 
         def on_class(node)
           return unless view_component_class?(node)
+          return if view_component_parent_class?(node)
 
           class_name = fully_qualified_name(node)
           return if preview_exists?(class_name)

--- a/spec/rubocop/cop/view_component/missing_preview_spec.rb
+++ b/spec/rubocop/cop/view_component/missing_preview_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe RuboCop::Cop::ViewComponent::MissingPreview, :config do
 
   context "when a preview file exists" do
     it "does not register an offense" do
-      allow(File).to receive(:exist?).and_return(true)
+      allow(File).to receive(:exist?).and_return(false)
+      allow(File).to receive(:exist?).with("/previews/user_preview.rb").and_return(true)
 
       expect_no_offenses(<<~RUBY, "/app/components/user_component.rb")
         class UserComponent < ViewComponent::Base
@@ -24,7 +25,8 @@ RSpec.describe RuboCop::Cop::ViewComponent::MissingPreview, :config do
 
   context "when no preview file exists" do
     it "registers an offense" do
-      allow(File).to receive(:exist?).and_return(false)
+      allow(File).to receive(:exist?).with("/previews/user_preview.rb").and_return(false)
+      allow(File).to receive(:exist?).with("/previews/user_component_preview.rb").and_return(false)
 
       expect_offense(<<~RUBY, "/app/components/user_component.rb")
         class UserComponent < ViewComponent::Base
@@ -46,7 +48,10 @@ RSpec.describe RuboCop::Cop::ViewComponent::MissingPreview, :config do
     end
 
     it "registers an offense for a component in a configured namespace" do
-      allow(File).to receive(:exist?).and_return(false)
+      allow(File).to receive(:exist?).with("/previews/v2/table_preview.rb").and_return(false)
+      allow(File).to receive(:exist?).with("/previews/v2/table_component_preview.rb").and_return(false)
+      allow(File).to receive(:exist?).with("/previews/table_preview.rb").and_return(false)
+      allow(File).to receive(:exist?).with("/previews/table_component_preview.rb").and_return(false)
 
       expect_offense(<<~RUBY, "/app/components/v2/table.rb")
         class V2::Table < SomeBase
@@ -103,8 +108,6 @@ RSpec.describe RuboCop::Cop::ViewComponent::MissingPreview, :config do
 
   context "when not a ViewComponent" do
     it "does not register an offense" do
-      allow(File).to receive(:exist?).and_return(false)
-
       expect_no_offenses(<<~RUBY, "/app/components/user_component.rb")
         class UserComponent
         end
@@ -114,8 +117,6 @@ RSpec.describe RuboCop::Cop::ViewComponent::MissingPreview, :config do
 
   context "when the class is itself a registered parent class" do
     it "does not register an offense for a built-in parent class" do
-      allow(File).to receive(:exist?).and_return(false)
-
       expect_no_offenses(<<~RUBY, "/app/components/application_component.rb")
         class ApplicationComponent < ViewComponent::Base
         end
@@ -134,8 +135,6 @@ RSpec.describe RuboCop::Cop::ViewComponent::MissingPreview, :config do
       end
 
       it "does not register an offense for the custom parent class" do
-        allow(File).to receive(:exist?).and_return(false)
-
         expect_no_offenses(<<~RUBY, "/app/components/base_component.rb")
           class BaseComponent < ViewComponent::Base
           end
@@ -155,8 +154,6 @@ RSpec.describe RuboCop::Cop::ViewComponent::MissingPreview, :config do
       end
 
       it "does not register an offense for the namespaced custom parent class" do
-        allow(File).to receive(:exist?).and_return(false)
-
         expect_no_offenses(<<~RUBY, "/app/components/my_app/base_component.rb")
           module MyApp
             class BaseComponent < ViewComponent::Base

--- a/spec/rubocop/cop/view_component/missing_preview_spec.rb
+++ b/spec/rubocop/cop/view_component/missing_preview_spec.rb
@@ -111,4 +111,59 @@ RSpec.describe RuboCop::Cop::ViewComponent::MissingPreview, :config do
       RUBY
     end
   end
+
+  context "when the class is itself a registered parent class" do
+    it "does not register an offense for a built-in parent class" do
+      allow(File).to receive(:exist?).and_return(false)
+
+      expect_no_offenses(<<~RUBY, "/app/components/application_component.rb")
+        class ApplicationComponent < ViewComponent::Base
+        end
+      RUBY
+    end
+
+    context "when a custom parent class is configured" do
+      let(:config) do
+        RuboCop::Config.new(
+          "ViewComponent/MissingPreview" => {
+            "Enabled" => true,
+            "PreviewPaths" => ["/previews"],
+            "ViewComponentParentClasses" => %w[ViewComponent::Base ApplicationComponent BaseComponent]
+          }
+        )
+      end
+
+      it "does not register an offense for the custom parent class" do
+        allow(File).to receive(:exist?).and_return(false)
+
+        expect_no_offenses(<<~RUBY, "/app/components/base_component.rb")
+          class BaseComponent < ViewComponent::Base
+          end
+        RUBY
+      end
+    end
+
+    context "when a namespaced custom parent class is configured" do
+      let(:config) do
+        RuboCop::Config.new(
+          "ViewComponent/MissingPreview" => {
+            "Enabled" => true,
+            "PreviewPaths" => ["/previews"],
+            "ViewComponentParentClasses" => %w[ViewComponent::Base ApplicationComponent MyApp::BaseComponent]
+          }
+        )
+      end
+
+      it "does not register an offense for the namespaced custom parent class" do
+        allow(File).to receive(:exist?).and_return(false)
+
+        expect_no_offenses(<<~RUBY, "/app/components/my_app/base_component.rb")
+          module MyApp
+            class BaseComponent < ViewComponent::Base
+            end
+          end
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #31.

## Summary

- Adds `view_component_parent_class?` to the shared `ViewComponent::Base` mixin, which computes the fully-qualified name of a class node and checks it against the configured `ViewComponentParentClasses` list
- Adds an early return in `MissingPreview#on_class` to skip classes that are themselves registered parents
- Handles namespaced parent classes (e.g. `MyApp::BaseComponent`) correctly

## Test plan

- [ ] `bundle exec rake` passes (85 examples, 0 failures, no RuboCop offenses)
- [ ] New specs cover: built-in parent (`ApplicationComponent`), custom top-level parent, and namespaced custom parent