### PR TITLE
MissingPreview: fix false negatives for nested module form with ComponentNamespaces

### DIFF
--- a/lib/rubocop/cop/view_component/base.rb
+++ b/lib/rubocop/cop/view_component/base.rb
@@ -9,7 +9,7 @@ module RuboCop
         def view_component_class?(node)
           return false unless node&.class_type?
 
-          class_source = node.identifier.source
+          class_source = fully_qualified_name(node)
           return true if component_namespaces.any? { |ns| class_source.start_with?(ns) }
 
           parent_class = node.parent_class

--- a/spec/rubocop/cop/view_component/missing_preview_spec.rb
+++ b/spec/rubocop/cop/view_component/missing_preview_spec.rb
@@ -88,6 +88,56 @@ RSpec.describe RuboCop::Cop::ViewComponent::MissingPreview, :config do
         end
       RUBY
     end
+
+    it "registers an offense for a component declared with nested module form when no preview exists" do
+      allow(File).to receive(:exist?).and_return(false)
+
+      expect_offense(<<~RUBY, "/app/components/v2/table.rb")
+        module V2
+          class Table < SomeBase
+                ^^^^^ No preview found for V2::Table (looked in: /previews).
+          end
+        end
+      RUBY
+    end
+
+    it "does not register an offense for a component declared with nested module form when preview exists" do
+      allow(File).to receive(:exist?).and_return(false)
+      allow(File).to receive(:exist?).with("/previews/v2/grouped_multi_select_preview.rb").and_return(true)
+
+      expect_no_offenses(<<~RUBY, "/app/components/v2/grouped_multi_select.rb")
+        module V2
+          class GroupedMultiSelect < V2::MultiSelect
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when the component is declared with nested module form" do
+    it "does not register an offense when preview exists at the namespaced path" do
+      allow(File).to receive(:exist?).and_return(false)
+      allow(File).to receive(:exist?).with("/previews/admin/page_component_preview.rb").and_return(true)
+
+      expect_no_offenses(<<~RUBY, "/app/components/admin/page_component.rb")
+        module Admin
+          class PageComponent < ApplicationComponent
+          end
+        end
+      RUBY
+    end
+
+    it "registers an offense when no preview exists" do
+      allow(File).to receive(:exist?).and_return(false)
+
+      expect_offense(<<~RUBY, "/app/components/admin/page_component.rb")
+        module Admin
+          class PageComponent < ApplicationComponent
+                ^^^^^^^^^^^^^ No preview found for Admin::PageComponent (looked in: /previews).
+          end
+        end
+      RUBY
+    end
   end
 
   context "when the namespace contains an acronym" do


### PR DESCRIPTION
Fixes #27

## Summary

- When a ViewComponent is declared as `module Foo; class Bar` (nested module form) rather than `class Foo::Bar` (compact form), `view_component_class?` was checking `node.identifier.source` (just `"Bar"`) against configured `ComponentNamespaces`
- Since `"Bar".start_with?("Foo::")` is always false, namespace-based detection never matched and no offense was registered even when the component had no preview
- Fix: use `fully_qualified_name(node)` instead so the check correctly uses `"Foo::Bar"`

## Test plan

- [ ] New test: registers offense for nested module form when no preview exists (ComponentNamespaces)
- [ ] New test: no offense for nested module form when preview exists (ComponentNamespaces)
- [ ] New test: no offense when preview exists at namespaced path (ViewComponent::Base parent)
- [ ] New test: registers offense for nested module form with no preview (ViewComponent::Base parent)
- [ ] `bundle exec rake` passes (89 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)