### PR TITLE
MissingPreview: add AllowSlotSubcomponents option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This gem provides several cops to enforce ViewComponent best practices:
 - **ViewComponent/PreferSlots** - Detect HTML parameters that should be slots
 - **ViewComponent/PreferComposition** - Avoid inheriting one ViewComponent from another (prefer composition)
 - **ViewComponent/TestRenderedOutput** - Encourage testing rendered output over private methods
-- **ViewComponent/MissingPreview** - Ensure every ViewComponent has a corresponding preview file (requires `PreviewPaths` configuration). Classes listed in `ViewComponentParentClasses` are automatically exempt, as abstract base classes are not rendered standalone.
+- **ViewComponent/MissingPreview** - Ensure every ViewComponent has a corresponding preview file (requires `PreviewPaths` configuration). Classes listed in `ViewComponentParentClasses` are automatically exempt, as abstract base classes are not rendered standalone. Set `AllowSlotSubcomponents: true` to also exempt slot subcomponents — nested classes inside a parent ViewComponent, or files in a sidecar directory whose parent component references them via `renders_one`/`renders_many`.
 
 ## Optional Configuration
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -22,6 +22,7 @@ ViewComponent/MissingPreview:
     - test/components/previews
     - spec/components/previews
   ComponentNamespaces: []
+  AllowSlotSubcomponents: false
 
 ViewComponent/NoGlobalState:
   Description: 'Avoid accessing global state (params, request, session, cookies,

--- a/lib/rubocop/cop/view_component/missing_preview.rb
+++ b/lib/rubocop/cop/view_component/missing_preview.rb
@@ -50,7 +50,17 @@ module RuboCop
           return false unless parent_file
 
           short_name = node.identifier.source
-          File.read(parent_file).match?(/\b#{Regexp.escape(short_name)}\b/)
+          parent_source = cached_file_read(parent_file)
+          # Match class name on the same line as renders_one/many OR within a
+          # short lambda block on the following lines (covers .new(...) inside
+          # ->(...) do ... end). We allow up to ~5 lines after renders_ to avoid
+          # false positives from unrelated later occurrences of the class name.
+          parent_source.match?(/renders_(one|many)\b[^\n]*(?:\n[^\n]*){0,5}\b#{Regexp.escape(short_name)}\b/)
+        end
+
+        def cached_file_read(path)
+          @file_cache ||= {}
+          @file_cache[path] ||= File.read(path)
         end
 
         def preview_exists?(class_name)

--- a/lib/rubocop/cop/view_component/missing_preview.rb
+++ b/lib/rubocop/cop/view_component/missing_preview.rb
@@ -18,6 +18,7 @@ module RuboCop
         def on_class(node)
           return unless view_component_class?(node)
           return if view_component_parent_class?(node)
+          return if allow_slot_subcomponents? && slot_subcomponent?(node)
 
           class_name = fully_qualified_name(node)
           return if preview_exists?(class_name)
@@ -26,6 +27,30 @@ module RuboCop
         end
 
         private
+
+        def allow_slot_subcomponents?
+          cop_config.fetch("AllowSlotSubcomponents", false)
+        end
+
+        def slot_subcomponent?(node)
+          nested_in_view_component?(node) || under_parent_component_dir?(node)
+        end
+
+        def nested_in_view_component?(node)
+          parent = node.each_ancestor(:class).first
+          parent && view_component_class?(parent)
+        end
+
+        def under_parent_component_dir?(node)
+          path = processed_source.path
+          return false unless path
+
+          parent_file = "#{File.dirname(path)}.rb"
+          return false unless File.exist?(parent_file)
+
+          short_name = node.identifier.source
+          File.read(parent_file).match?(/\brenders_(one|many)\b[^#\n]*\b#{Regexp.escape(short_name)}\b/)
+        end
 
         def preview_exists?(class_name)
           preview_paths.any? do |preview_path|

--- a/lib/rubocop/cop/view_component/missing_preview.rb
+++ b/lib/rubocop/cop/view_component/missing_preview.rb
@@ -45,11 +45,12 @@ module RuboCop
           path = processed_source.path
           return false unless path
 
-          parent_file = "#{File.dirname(path)}.rb"
-          return false unless File.exist?(parent_file)
+          dir = File.dirname(path)
+          parent_file = ["#{dir}.rb", "#{dir}_component.rb"].find { |f| File.exist?(f) }
+          return false unless parent_file
 
           short_name = node.identifier.source
-          File.read(parent_file).match?(/\brenders_(one|many)\b[^#\n]*\b#{Regexp.escape(short_name)}\b/)
+          File.read(parent_file).match?(/\b#{Regexp.escape(short_name)}\b/)
         end
 
         def preview_exists?(class_name)

--- a/spec/expected_polaris_failures.yml
+++ b/spec/expected_polaris_failures.yml
@@ -10,18 +10,11 @@ ViewComponent/ComponentSuffix:
   - 'app/components/polaris/layout/section.rb'
   - 'app/components/polaris/text_field_component.rb'
 ViewComponent/MissingPreview:
-  - 'app/components/polaris/button_group_component.rb'
   - 'app/components/polaris/choice_component.rb'
-  - 'app/components/polaris/description_list_component.rb'
-  - 'app/components/polaris/filters_component.rb'
   - 'app/components/polaris/inline_code_component.rb'
   - 'app/components/polaris/label_component.rb'
   - 'app/components/polaris/labelled_component.rb'
-  - 'app/components/polaris/list_component.rb'
-  - 'app/components/polaris/page_component.rb'
   - 'app/components/polaris/placeholder_component.rb'
-  - 'app/components/polaris/shopify_navigation_component.rb'
-  - 'app/components/polaris/text_field_component.rb'
 ViewComponent/NoGlobalState:
   - 'app/components/polaris/shopify_navigation_component.rb'
 ViewComponent/PreferPrivateMethods:

--- a/spec/rubocop/cop/view_component/missing_preview_spec.rb
+++ b/spec/rubocop/cop/view_component/missing_preview_spec.rb
@@ -229,6 +229,24 @@ RSpec.describe RuboCop::Cop::ViewComponent::MissingPreview, :config do
         RUBY
       end
 
+      it "does not register an offense when class is instantiated inside a renders_one lambda" do
+        allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:exist?)
+          .with("/app/components/polaris/frame_component.rb").and_return(true)
+        allow(File).to receive(:read)
+          .with("/app/components/polaris/frame_component.rb")
+          .and_return(<<~RUBY)
+            renders_one :save_bar, ->(**system_arguments) do
+              SaveBarComponent.new(**system_arguments)
+            end
+          RUBY
+
+        expect_no_offenses(<<~RUBY, "/app/components/polaris/frame_component/save_bar_component.rb")
+          class SaveBarComponent < ApplicationComponent
+          end
+        RUBY
+      end
+
       it "registers an offense when parent file does not declare a matching slot" do
         allow(File).to receive(:exist?).and_return(false)
         allow(File).to receive(:exist?)

--- a/spec/rubocop/cop/view_component/missing_preview_spec.rb
+++ b/spec/rubocop/cop/view_component/missing_preview_spec.rb
@@ -165,6 +165,125 @@ RSpec.describe RuboCop::Cop::ViewComponent::MissingPreview, :config do
     end
   end
 
+  context "when AllowSlotSubcomponents is true" do
+    let(:config) do
+      RuboCop::Config.new(
+        "ViewComponent/MissingPreview" => {
+          "Enabled" => true,
+          "PreviewPaths" => ["/previews"],
+          "ViewComponentParentClasses" => %w[ViewComponent::Base ApplicationComponent],
+          "AllowSlotSubcomponents" => true
+        }
+      )
+    end
+
+    context "when a nested class inside a parent ViewComponent" do
+      it "registers an offense only for the parent, not the nested class" do
+        allow(File).to receive(:exist?).and_return(false)
+
+        expect_offense(<<~RUBY, "/app/components/ui/card_component.rb")
+          module UI
+            class CardComponent < ApplicationComponent
+                  ^^^^^^^^^^^^^ No preview found for UI::CardComponent (looked in: /previews).
+              renders_many :items, "ItemComponent"
+              class ItemComponent < ApplicationComponent
+              end
+            end
+          end
+        RUBY
+      end
+
+      it "does not register any offense when the parent has a preview" do
+        allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:exist?).with("/previews/ui/card_component_preview.rb").and_return(true)
+
+        expect_no_offenses(<<~RUBY, "/app/components/ui/card_component.rb")
+          module UI
+            class CardComponent < ApplicationComponent
+              renders_many :items, "ItemComponent"
+              class ItemComponent < ApplicationComponent
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "when a sibling file under a parent component's directory" do
+      it "does not register an offense when parent file declares a slot referencing this class" do
+        allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:exist?).with("/app/components/polaris/action_list.rb").and_return(false)
+        allow(File).to receive(:exist?)
+          .with("/app/components/polaris/action_list_component.rb").and_return(true)
+        allow(File).to receive(:read)
+          .with("/app/components/polaris/action_list_component.rb")
+          .and_return('renders_many :items, "ItemComponent"')
+
+        expect_no_offenses(<<~RUBY, "/app/components/polaris/action_list_component/item_component.rb")
+          module Polaris
+            class ActionListComponent
+              class ItemComponent < ApplicationComponent
+              end
+            end
+          end
+        RUBY
+      end
+
+      it "registers an offense when parent file does not declare a matching slot" do
+        allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:exist?)
+          .with("/app/components/polaris/action_list_component.rb").and_return(true)
+        allow(File).to receive(:read)
+          .with("/app/components/polaris/action_list_component.rb")
+          .and_return("renders_many :sections, \"SectionComponent\"")
+
+        expect_offense(<<~RUBY, "/app/components/polaris/action_list_component/item_component.rb")
+          class ItemComponent < ApplicationComponent
+                ^^^^^^^^^^^^^ No preview found for ItemComponent (looked in: /previews).
+          end
+        RUBY
+      end
+
+      it "registers an offense when parent file does not exist" do
+        allow(File).to receive(:exist?).and_return(false)
+
+        expect_offense(<<~RUBY, "/app/components/polaris/action_list_component/item_component.rb")
+          class ItemComponent < ApplicationComponent
+                ^^^^^^^^^^^^^ No preview found for ItemComponent (looked in: /previews).
+          end
+        RUBY
+      end
+    end
+
+    context "when AllowSlotSubcomponents is false (default)" do
+      let(:config) do
+        RuboCop::Config.new(
+          "ViewComponent/MissingPreview" => {
+            "Enabled" => true,
+            "PreviewPaths" => ["/previews"],
+            "ViewComponentParentClasses" => %w[ViewComponent::Base ApplicationComponent],
+            "AllowSlotSubcomponents" => false
+          }
+        )
+      end
+
+      it "registers an offense for a nested class even when inside a parent component" do
+        allow(File).to receive(:exist?).and_return(false)
+
+        expect_offense(<<~RUBY, "/app/components/ui/card_component.rb")
+          module UI
+            class CardComponent < ApplicationComponent
+                  ^^^^^^^^^^^^^ No preview found for UI::CardComponent (looked in: /previews).
+              class ItemComponent < ApplicationComponent
+                    ^^^^^^^^^^^^^ No preview found for UI::CardComponent::ItemComponent (looked in: /previews).
+              end
+            end
+          end
+        RUBY
+      end
+    end
+  end
+
   context "when the class is itself a registered parent class" do
     it "does not register an offense for a built-in parent class" do
       expect_no_offenses(<<~RUBY, "/app/components/application_component.rb")

--- a/verification/polaris_rubocop_config.yml
+++ b/verification/polaris_rubocop_config.yml
@@ -9,40 +9,17 @@ ViewComponent:
 ViewComponent/MissingPreview:
   PreviewPaths:
     - demo/app/previews
+  AllowSlotSubcomponents: true
   Exclude:
     - app/components/polaris/base_component.rb
     - app/components/polaris/base_button.rb
     - app/components/polaris/base_checkbox.rb
     - app/components/polaris/base_radio_button.rb
-    # Sub-components are rendered as part of their parent component's preview
-    # rather than having dedicated preview files
-    - app/components/polaris/action_list/item_component.rb
-    - app/components/polaris/action_list/section_component.rb
+    # Sub-components not directly referenced in a parent renders_one/renders_many declaration
     - app/components/polaris/autocomplete/action_component.rb
-    - app/components/polaris/autocomplete/option_component.rb
-    - app/components/polaris/autocomplete/section_component.rb
-    - app/components/polaris/card/header_component.rb
-    - app/components/polaris/card/section_component.rb
     - app/components/polaris/data_table/cell_component.rb
     - app/components/polaris/data_table/column_component.rb
-    - app/components/polaris/exception_list/item_component.rb
-    - app/components/polaris/form_layout/group_component.rb
-    - app/components/polaris/form_layout/item_component.rb
-    - app/components/polaris/frame/save_bar_component.rb
-    - app/components/polaris/frame/top_bar_component.rb
     - app/components/polaris/index_table/cell_component.rb
     - app/components/polaris/index_table/column_component.rb
-    - app/components/polaris/modal/section_component.rb
-    - app/components/polaris/navigation/item_component.rb
-    - app/components/polaris/navigation/section_component.rb
-    - app/components/polaris/new_tabs/tab_component.rb
-    - app/components/polaris/option_list/checkbox_component.rb
-    - app/components/polaris/option_list/option_component.rb
-    - app/components/polaris/option_list/radio_button_component.rb
-    - app/components/polaris/option_list/section_component.rb
-    - app/components/polaris/popover/pane_component.rb
     - app/components/polaris/popover/section_component.rb
-    - app/components/polaris/resource_item/shortcut_actions_component.rb
-    - app/components/polaris/stack/item_component.rb
-    - app/components/polaris/tabs/tab_component.rb
     - app/components/polaris/top_bar/user_menu_component.rb


### PR DESCRIPTION
Closes #32.

## Summary

- Adds `AllowSlotSubcomponents: false` (opt-in) config flag to `ViewComponent/MissingPreview`
- When enabled, skips two patterns of slot subcomponents:
  - **Pattern A** — a class nested directly inside a parent ViewComponent in the same AST
  - **Pattern B** — a sibling file under a parent component's directory, where the parent file contains a `renders_one`/`renders_many` declaration referencing this class's leaf name
- Adds 6 new specs covering both patterns, the disabled-by-default case, and edge cases

## Acceptance criterion from the issue

`verification/polaris_rubocop_config.yml`'s ~30-entry `MissingPreview.Exclude` block should be replaceable by `AllowSlotSubcomponents: true` with no snapshot regressions.

## Test plan

- [ ] `bundle exec rake` passes (95 examples, 0 failures, 0 offenses)
- [ ] Verify polaris snapshot: `script/verify polaris` with `AllowSlotSubcomponents: true` in the config produces no regressions