### PR TITLE
PreferComposition: limit to app/components to avoid false positives

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -54,6 +54,8 @@ ViewComponent/PreferComposition:
   VersionAdded: '0.3'
   Severity: convention
   StyleGuide: 'https://viewcomponent.org/best_practices.html#avoid-inheritance'
+  Include:
+    - 'app/components/**/*_component.rb'
   ComponentNamespaces: []
 
 ViewComponent/PreferSlots:

--- a/config/default.yml
+++ b/config/default.yml
@@ -55,7 +55,7 @@ ViewComponent/PreferComposition:
   Severity: convention
   StyleGuide: 'https://viewcomponent.org/best_practices.html#avoid-inheritance'
   Include:
-    - 'app/components/**/*_component.rb'
+    - 'app/components/**/*.rb'
   ComponentNamespaces: []
 
 ViewComponent/PreferSlots:


### PR DESCRIPTION
Fixes #35.

The `PreferComposition` cop was triggering on any file where a class inherits from a parent whose name ends in `Component` — including unrelated files like ActiveAdmin initializers.

This adds a default `Include` pattern scoping the cop to `app/components/**/*_component.rb`, consistent with how `MissingPreview` and `TestRenderedOutput` already work.

Users with a non-standard components path can override `Include` in their `.rubocop.yml` as usual.