### PR TITLE
ComponentSuffix: limit to app/components/**/*.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ ViewComponent:
     - MyApp::BaseComponent
 ```
 
+### Components Directory
+
+Several cops (`ComponentSuffix`, `PreferComposition`, `MissingPreview`, `TestRenderedOutput`) default to running only on files under `app/components/`. If your project uses a different path, override `Include` in your `.rubocop.yml`:
+
+```yaml
+# .rubocop.yml
+ViewComponent/ComponentSuffix:
+  Include:
+    - 'app/components/**/*.rb'
+    - 'engines/*/app/components/**/*.rb'
+```
+
 ### No Super
 
 View Component convention is to not calling `super` in component initializers, but that may cause `Lint/MissingSuper` failures from RuboCop. We suggest disabling that rule for your view components directory, for example:

--- a/config/default.yml
+++ b/config/default.yml
@@ -10,6 +10,8 @@ ViewComponent/ComponentSuffix:
   VersionAdded: '0.1'
   Severity: convention
   StyleGuide: 'https://viewcomponent.org/best_practices.html'
+  Include:
+    - 'app/components/**/*.rb'
 
 ViewComponent/MissingPreview:
   Description: 'Ensure every ViewComponent has a corresponding preview file.'


### PR DESCRIPTION
Scopes `ComponentSuffix` to `app/components/**/*.rb` by default, consistent with `MissingPreview` and `TestRenderedOutput`. This avoids false positives in unrelated files (e.g. initializers, concerns) that happen to define classes inheriting from ViewComponent parents.

Users with a non-standard path can override `Include` in their `.rubocop.yml`.