### PR TITLE
Fix grammar and naming in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ ViewComponent/ComponentSuffix:
 
 ### No Super
 
-View Component convention is to not calling `super` in component initializers, but that may cause `Lint/MissingSuper` failures from RuboCop. We suggest disabling that rule for your view components directory, for example:
+ViewComponent convention is to not call `super` in component initializers, but that may cause `Lint/MissingSuper` failures from RuboCop. We suggest disabling that rule for your view components directory, for example:
 
 ```yaml
 # .rubocop.yml


### PR DESCRIPTION
Fix two issues in the "No Super" section:

- "to not calling" → "to not call" (grammatical infinitive form)
- "View Component" → "ViewComponent" (consistent naming with the rest of the README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)