### PR TITLE
Update govuk verification results

### DIFF
--- a/spec/expected_govuk_failures.yml
+++ b/spec/expected_govuk_failures.yml
@@ -7,10 +7,12 @@ ViewComponent/ComponentSuffix:
   - 'app/components/govuk_component/notification_banner_component.rb'
   - 'app/components/govuk_component/pagination_component/adjacent_page.rb'
   - 'app/components/govuk_component/pagination_component/item.rb'
+  - 'app/components/govuk_component/panel_component.rb'
   - 'app/components/govuk_component/tab_component.rb'
 ViewComponent/PreferPrivateMethods:
   - 'app/components/govuk_component/base.rb'
   - 'app/components/govuk_component/notification_banner_component.rb'
+  - 'app/components/govuk_component/panel_component.rb'
   - 'app/components/govuk_component/service_navigation_component.rb'
   - 'app/components/govuk_component/tab_component.rb'
 ViewComponent/TestRenderedOutput:


### PR DESCRIPTION
Regenerates `spec/expected_govuk_failures.yml` to fix the failing x-govuk verification.

govuk-components main added a nested `Action` class to `panel_component.rb` since the last snapshot, which triggers two new (legitimate) offenses:
- ViewComponent/ComponentSuffix
- ViewComponent/PreferPrivateMethods

Run: `script/verify govuk --regenerate`