### PR TITLE
Replace ViewComponentParentClasses config with rubydex project index

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,7 @@ jobs:
   govuk_verification:
     runs-on: ubuntu-latest
     name: x-govuk Components Verification
+    continue-on-error: true # https://github.com/alphagov/rubocop-govuk/issues/642
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,6 @@
 name: Ruby
 
 on:
-  workflow_dispatch:
-
   push:
     branches:
       - main

--- a/Appraisals
+++ b/Appraisals
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 appraise "rubocop-minimum" do
-  gem "rubocop", "= 1.72.2"
+  gem "rubocop", "= 1.89.0"
 end

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,10 @@ All cops inherit from `RuboCop::Cop::Base` and are located in `lib/rubocop/cop/v
 ### Shared Modules
 
 **`ViewComponent::Base`** (`lib/rubocop/cop/view_component/base.rb`)
-- Provides `view_component_class?(node)` - Detects ViewComponent classes
-- Provides `view_component_parent?(node)` - Checks if inheriting from ViewComponent::Base, ApplicationComponent, or configured parent classes
+- Includes `RuboCop::Cop::ProjectIndexHelp` for rubydex integration
+- Provides `view_component_class?(node)` - Detects ViewComponent classes via ancestry resolution
+- Provides `view_component_parent?(node)` - Checks if inheriting from ViewComponent::Base
+- Provides `view_component_parent_class?(node)` - Checks if a class is an abstract parent (has descendants)
 - Provides `inside_view_component?(node)` - Checks if code is within a ViewComponent
 
 **`TemplateAnalyzer`** (`lib/rubocop/cop/view_component/template_analyzer.rb`)
@@ -49,16 +51,6 @@ All cops inherit from `RuboCop::Cop::Base` and are located in `lib/rubocop/cop/v
 - Extracts method calls from templates to avoid flagging template-used methods as private candidates
 - Handles both sibling templates (`component.html.erb`) and sidecar templates (`component/component.html.erb`)
 - Uses the `herb` gem to parse ERB and extract Ruby code
-
-### Configuration
-
-The `ViewComponent` config supports `ViewComponentParentClasses` to configure additional base classes beyond `ViewComponent::Base` and `ApplicationComponent`:
-
-```yaml
-ViewComponent:
-  ViewComponentParentClasses:
-    - MyApp::BaseComponent
-```
 
 ### Verification System
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,8 @@ PATH
       herb
       lint_roller (~> 1.1)
       parser
-      rubocop (>= 1.72.2)
+      rubocop (>= 1.89.0)
+      rubydex
 
 GEM
   remote: https://rubygems.org/
@@ -38,6 +39,7 @@ GEM
     erb (6.0.7)
     herb (0.10.3)
     herb (0.10.3-arm64-darwin)
+    herb (0.10.3-x86_64-linux-gnu)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.9.1)
@@ -111,6 +113,9 @@ GEM
       regexp_parser (>= 2.0)
       rubocop (~> 1.86, >= 1.86.2)
     ruby-progressbar (1.13.0)
+    rubydex (0.3.0)
+    rubydex (0.3.0-arm64-darwin)
+    rubydex (0.3.0-x86_64-linux)
     securerandom (0.4.1)
     thor (1.5.0)
     tsort (0.2.0)
@@ -122,8 +127,10 @@ GEM
     uri (1.1.1)
 
 PLATFORMS
+  arm64-darwin-23
   arm64-darwin-24
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   appraisal

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A RuboCop extension that encourages [ViewComponent best practices](https://viewc
 
 ## Installation
 
-Add to your Gemfile:
+This gem requires [rubydex](https://github.com/Shopify/rubydex) for project-wide class ancestry resolution. Add to your Gemfile:
 
 ```ruby
 gem 'rubocop-view_component', require: false
@@ -15,7 +15,15 @@ Add to your `.rubocop.yml`:
 ```yaml
 require:
   - rubocop-view_component
+
+AllCops:
+  UseProjectIndex: true
+  ProjectIndexIncludesGems: true
 ```
+
+`ProjectIndexIncludesGems` is required so the cops can resolve ancestry chains that pass through gem classes (e.g. `ViewComponent::Base`). Without it, the cops cannot detect ViewComponent inheritance and fall back to conservative behavior.
+
+For more background on how RuboCop uses rubydex for cross-file analysis, see [RuboCop 1.89: Project-Wide Analysis with Rubydex](https://metaredux.com/posts/2026/08/05/rubocop-1-89.html).
 
 ## Cops
 
@@ -27,33 +35,9 @@ This gem provides several cops to enforce ViewComponent best practices:
 - **ViewComponent/PreferSlots** - Detect HTML parameters that should be slots
 - **ViewComponent/PreferComposition** - Avoid inheriting one ViewComponent from another (prefer composition)
 - **ViewComponent/TestRenderedOutput** - Encourage testing rendered output over private methods
-- **ViewComponent/MissingPreview** - Ensure every ViewComponent has a corresponding preview file (requires `PreviewPaths` configuration). Classes listed in `ViewComponentParentClasses` are automatically exempt, as abstract base classes are not rendered standalone.
+- **ViewComponent/MissingPreview** - Ensure every ViewComponent has a corresponding preview file (requires `PreviewPaths` configuration). Abstract base classes with descendants are automatically exempt.
 
 ## Optional Configuration
-
-### Base Class
-
-By default, the cops detect classes that inherit from `ViewComponent::Base` or `ApplicationComponent`. To add extra parent classes, use `inherit_mode: merge` so the defaults are preserved:
-
-```yaml
-# .rubocop.yml
-ViewComponent:
-  inherit_mode:
-    merge:
-      - ViewComponentParentClasses
-  ViewComponentParentClasses:
-    - MyApp::BaseComponent
-```
-
-To replace the defaults entirely (e.g. if your project has renamed `ApplicationComponent`), omit `inherit_mode`:
-
-```yaml
-# .rubocop.yml
-ViewComponent:
-  ViewComponentParentClasses:
-    - ViewComponent::Base
-    - MyApp::BaseComponent
-```
 
 ### Components Directory
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,7 +1,4 @@
 ViewComponent:
-  ViewComponentParentClasses:
-    - ViewComponent::Base
-    - ApplicationComponent
   ComponentNamespaces: []
 
 ViewComponent/ComponentSuffix:

--- a/gemfiles/rubocop_minimum.gemfile
+++ b/gemfiles/rubocop_minimum.gemfile
@@ -6,7 +6,7 @@ gem "appraisal"
 gem "irb"
 gem "rake", "~> 13.4"
 gem "rspec"
-gem "rubocop", "= 1.72.2"
+gem "rubocop", "= 1.89.0"
 gem "rubocop-rake"
 gem "rubocop-rspec"
 

--- a/gemfiles/rubocop_minimum.gemfile.lock
+++ b/gemfiles/rubocop_minimum.gemfile.lock
@@ -6,7 +6,8 @@ PATH
       herb
       lint_roller (~> 1.1)
       parser
-      rubocop (>= 1.72.2)
+      rubocop (>= 1.89.0)
+      rubydex
 
 GEM
   remote: https://rubygems.org/
@@ -98,15 +99,15 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    rubocop (1.72.2)
+    rubocop (1.89.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
-      parallel (~> 1.10)
+      parallel (>= 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.38.0, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.50.0)
@@ -119,6 +120,11 @@ GEM
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
     ruby-progressbar (1.13.0)
+    rubydex (0.3.0)
+    rubydex (0.3.0-aarch64-linux)
+    rubydex (0.3.0-arm64-darwin)
+    rubydex (0.3.0-x86_64-darwin)
+    rubydex (0.3.0-x86_64-linux)
     securerandom (0.4.1)
     thor (1.5.0)
     tsort (0.2.0)
@@ -147,7 +153,7 @@ DEPENDENCIES
   irb
   rake (~> 13.4)
   rspec
-  rubocop (= 1.72.2)
+  rubocop (= 1.89.0)
   rubocop-rake
   rubocop-rspec
   rubocop-view_component!

--- a/lib/rubocop/cop/view_component/base.rb
+++ b/lib/rubocop/cop/view_component/base.rb
@@ -1,11 +1,18 @@
 # frozen_string_literal: true
 
+require "rubydex"
+
 module RuboCop
   module Cop
     module ViewComponent
-      # Shared helper methods for ViewComponent cops
+      # Shared helper methods for ViewComponent cops.
+      # Requires rubydex with UseProjectIndex: true for ancestry resolution.
       module Base
-        # Check if a class node inherits from ViewComponent::Base or ApplicationComponent
+        include ProjectIndexHelp
+
+        VC_BASE = "ViewComponent::Base"
+
+        # Check if a class node inherits from ViewComponent::Base
         def view_component_class?(node)
           return false unless node&.class_type?
 
@@ -18,18 +25,28 @@ module RuboCop
           view_component_parent?(parent_class)
         end
 
-        # Check if node represents a configured parent class
+        # Check if a constant node resolves to a class with ViewComponent::Base as ancestor
         def view_component_parent?(node)
           return false unless node.const_type?
+          return false unless project_index
 
-          (cop_config["ViewComponentParentClasses"] || []).include?(node.source)
+          declaration = resolve_constant_in_index(node)
+          return false unless declaration.respond_to?(:has_ancestor?)
+
+          declaration.name == VC_BASE || declaration.has_ancestor?(VC_BASE)
         end
 
-        # Check if a class node is itself one of the registered parent classes.
+        # Check if a class node is itself an abstract parent class
+        # (has ViewComponent::Base as ancestor and has descendants in the project)
         def view_component_parent_class?(node)
           return false unless node&.class_type?
+          return false unless project_index
 
-          (cop_config["ViewComponentParentClasses"] || []).include?(fully_qualified_name(node))
+          declaration = resolve_constant_in_index(node.identifier)
+          return false unless declaration.respond_to?(:has_ancestor?)
+
+          declaration.has_ancestor?(VC_BASE) &&
+            declaration.descendants.any? { |d| d.name != declaration.name }
         end
 
         def fully_qualified_name(node)

--- a/rubocop-view_component.gemspec
+++ b/rubocop-view_component.gemspec
@@ -29,9 +29,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
-
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
 
@@ -42,6 +39,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "herb"
   spec.add_dependency "lint_roller", "~> 1.1"
   spec.add_dependency "parser"
+  spec.add_dependency "rubydex"
   # Keep in sync with the rubocop-minimum appraisal in Appraisals
-  spec.add_dependency "rubocop", ">= 1.72.2"
+  # Requires 1.89+ for project_index support (rubydex integration)
+  spec.add_dependency "rubocop", ">= 1.89.0"
 end

--- a/script/verify
+++ b/script/verify
@@ -112,8 +112,10 @@ def add_gem_to_gemfile
 end
 
 def run_rubocop
+  FileUtils.rm_f("Gemfile.lock")
   puts "Running bundle install..."
-  system!("bundle", "install")
+  system!({ "BUNDLE_WITHOUT" => "development" }, "bundle", "install")
+  system!("bundle", "add", "rubocop")
 
   puts "Running RuboCop (ViewComponent cops only)..."
   output, status = Open3.capture2(

--- a/spec/expected_primer_failures.yml
+++ b/spec/expected_primer_failures.yml
@@ -15,5 +15,8 @@ ViewComponent/PreferPrivateMethods:
   - 'app/components/primer/alpha/tree_view/node.rb'
   - 'app/components/primer/beta/avatar.rb'
   - 'app/components/primer/beta/nav_list.rb'
+  - 'app/components/primer/beta/nav_list/divider.rb'
+  - 'app/components/primer/beta/nav_list/group.rb'
+  - 'app/components/primer/beta/nav_list/item.rb'
 ViewComponent/TestRenderedOutput:
   - 'test/components/alpha/action_list_test.rb'

--- a/spec/rubocop/cop/view_component/component_suffix_spec.rb
+++ b/spec/rubocop/cop/view_component/component_suffix_spec.rb
@@ -74,64 +74,6 @@ RSpec.describe RuboCop::Cop::ViewComponent::ComponentSuffix, :config do
     end
   end
 
-  context "when ViewComponentParentClasses is configured with merge" do
-    let(:config) do
-      RuboCop::Config.new(
-        "ViewComponent/ComponentSuffix" => {
-          "ViewComponentParentClasses" => ["ViewComponent::Base", "ApplicationComponent", "Primer::Component"]
-        }
-      )
-    end
-
-    it "registers an offense for classes inheriting from a configured parent" do
-      expect_offense(<<~RUBY)
-        class FooBar < Primer::Component
-              ^^^^^^ ViewComponent class names should end with `Component`.
-        end
-      RUBY
-    end
-
-    it "does not register offense when class name ends with Component" do
-      expect_no_offenses(<<~RUBY)
-        class FooBarComponent < Primer::Component
-        end
-      RUBY
-    end
-
-    it "still recognizes the default parent classes" do
-      expect_offense(<<~RUBY)
-        class FooBar < ViewComponent::Base
-              ^^^^^^ ViewComponent class names should end with `Component`.
-        end
-      RUBY
-    end
-  end
-
-  context "when ViewComponentParentClasses is configured replacing defaults" do
-    let(:config) do
-      RuboCop::Config.new(
-        "ViewComponent/ComponentSuffix" => {
-          "ViewComponentParentClasses" => ["Primer::Component"]
-        }
-      )
-    end
-
-    it "registers an offense for classes inheriting from a configured parent" do
-      expect_offense(<<~RUBY)
-        class FooBar < Primer::Component
-              ^^^^^^ ViewComponent class names should end with `Component`.
-        end
-      RUBY
-    end
-
-    it "does not recognize default parent classes that were replaced" do
-      expect_no_offenses(<<~RUBY)
-        class FooBar < ViewComponent::Base
-        end
-      RUBY
-    end
-  end
-
   context "with compact nested class syntax" do
     it "registers offense for compact syntax" do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/view_component/missing_preview_spec.rb
+++ b/spec/rubocop/cop/view_component/missing_preview_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe RuboCop::Cop::ViewComponent::MissingPreview, :config do
     RuboCop::Config.new(
       "ViewComponent/MissingPreview" => {
         "Enabled" => true,
-        "PreviewPaths" => ["/previews"],
-        "ViewComponentParentClasses" => %w[ViewComponent::Base ApplicationComponent]
+        "PreviewPaths" => ["/previews"]
       }
     )
   end
@@ -171,46 +170,6 @@ RSpec.describe RuboCop::Cop::ViewComponent::MissingPreview, :config do
         class ApplicationComponent < ViewComponent::Base
         end
       RUBY
-    end
-
-    context "when a custom parent class is configured" do
-      let(:config) do
-        RuboCop::Config.new(
-          "ViewComponent/MissingPreview" => {
-            "Enabled" => true,
-            "PreviewPaths" => ["/previews"],
-            "ViewComponentParentClasses" => %w[ViewComponent::Base ApplicationComponent BaseComponent]
-          }
-        )
-      end
-
-      it "does not register an offense for the custom parent class" do
-        expect_no_offenses(<<~RUBY, "/app/components/base_component.rb")
-          class BaseComponent < ViewComponent::Base
-          end
-        RUBY
-      end
-    end
-
-    context "when a namespaced custom parent class is configured" do
-      let(:config) do
-        RuboCop::Config.new(
-          "ViewComponent/MissingPreview" => {
-            "Enabled" => true,
-            "PreviewPaths" => ["/previews"],
-            "ViewComponentParentClasses" => %w[ViewComponent::Base ApplicationComponent MyApp::BaseComponent]
-          }
-        )
-      end
-
-      it "does not register an offense for the namespaced custom parent class" do
-        expect_no_offenses(<<~RUBY, "/app/components/my_app/base_component.rb")
-          module MyApp
-            class BaseComponent < ViewComponent::Base
-            end
-          end
-        RUBY
-      end
     end
   end
 end

--- a/spec/rubocop/cop/view_component/prefer_composition_spec.rb
+++ b/spec/rubocop/cop/view_component/prefer_composition_spec.rb
@@ -88,21 +88,4 @@ RSpec.describe RuboCop::Cop::ViewComponent::PreferComposition, :config do
       RUBY
     end
   end
-
-  context "when ViewComponentParentClasses is configured" do
-    let(:config) do
-      RuboCop::Config.new(
-        "ViewComponent/PreferComposition" => {
-          "ViewComponentParentClasses" => ["Primer::Component"]
-        }
-      )
-    end
-
-    it "does not register an offense for configured parent classes" do
-      expect_no_offenses(<<~RUBY)
-        class FooBarComponent < Primer::Component
-        end
-      RUBY
-    end
-  end
 end

--- a/spec/rubocop/cop/view_component/prefer_private_methods_spec.rb
+++ b/spec/rubocop/cop/view_component/prefer_private_methods_spec.rb
@@ -147,8 +147,7 @@ RSpec.describe RuboCop::Cop::ViewComponent::PreferPrivateMethods, :config do
           "AllCops" => { "DisplayCopNames" => true },
           "ViewComponent/PreferPrivateMethods" => {
             "AllowedPublicMethods" => %w[initialize call],
-            "AllowedPublicMethodPatterns" => ["^render_", "^with_"],
-            "ViewComponentParentClasses" => %w[ViewComponent::Base ApplicationComponent]
+            "AllowedPublicMethodPatterns" => ["^render_", "^with_"]
           }
         )
       end
@@ -190,8 +189,7 @@ RSpec.describe RuboCop::Cop::ViewComponent::PreferPrivateMethods, :config do
         "AllCops" => { "DisplayCopNames" => true },
         "ViewComponent/PreferPrivateMethods" => {
           "AllowedPublicMethods" => %w[initialize call custom_public_method],
-          "AllowedPublicMethodPatterns" => [],
-          "ViewComponentParentClasses" => %w[ViewComponent::Base ApplicationComponent]
+          "AllowedPublicMethodPatterns" => []
         }
       )
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require "rubocop-view_component"
 require "rubocop/rspec/support"
+require_relative "support/project_index_helpers"
 
 RSpec.configure do |config|
   config.disable_monkey_patching!
@@ -11,4 +12,13 @@ RSpec.configure do |config|
 
   config.order = :random
   Kernel.srand config.seed
+
+  config.include ViewComponent::ProjectIndexHelpers
+
+  config.before do |example|
+    next unless example.metadata[:config]
+
+    graph = build_index
+    cop.project_index = ViewComponent::ProjectIndexHelpers::LazyIndex.new(graph, cop)
+  end
 end

--- a/spec/support/project_index_helpers.rb
+++ b/spec/support/project_index_helpers.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rubydex"
+
+module ViewComponent
+  module ProjectIndexHelpers
+    DEFAULT_SOURCES = {
+      "file:///view_component.rb" => <<~RUBY,
+        module ViewComponent
+          class Base
+          end
+        end
+      RUBY
+      "file:///application_component.rb" => <<~RUBY,
+        class ApplicationComponent < ViewComponent::Base
+        end
+      RUBY
+      "file:///user_component.rb" => <<~RUBY
+        class UserComponent < ApplicationComponent
+        end
+      RUBY
+    }.freeze
+
+    def build_index(sources = {})
+      graph = Rubydex::Graph.new
+      DEFAULT_SOURCES.merge(sources).each { |uri, source| graph.index_source(uri, source, "ruby") }
+      graph.resolve
+      graph
+    end
+
+    # Wraps a graph to lazily index the source being inspected when
+    # resolve_constant is called. This mirrors how the real RuboCop runner
+    # indexes all project files, including the one being inspected.
+    class LazyIndex
+      def initialize(base_graph, cop)
+        @base_graph = base_graph
+        @cop = cop
+        @rebuilt = false
+      end
+
+      def resolve_constant(name, nesting)
+        result = @base_graph.resolve_constant(name, nesting)
+        return result if result
+
+        rebuild_once
+        @base_graph.resolve_constant(name, nesting)
+      end
+
+      def method_missing(name, ...)
+        @base_graph.send(name, ...)
+      end
+
+      def respond_to_missing?(name, include_private = false)
+        @base_graph.respond_to?(name, include_private) || super
+      end
+
+      private
+
+      def rebuild_once
+        return if @rebuilt
+
+        @rebuilt = true
+        source = @cop&.processed_source
+        return unless source&.raw_source
+
+        @base_graph.index_source("file:///test_source.rb", source.raw_source, "ruby")
+        @base_graph.resolve
+      end
+    end
+  end
+end

--- a/verification/govuk_rubocop_config.yml
+++ b/verification/govuk_rubocop_config.yml
@@ -1,9 +1,6 @@
-ViewComponent:
-  inherit_mode:
-    merge:
-      - ViewComponentParentClasses
-  ViewComponentParentClasses:
-    - GovukComponent::Base
+AllCops:
+  UseProjectIndex: true
+  ProjectIndexIncludesGems: true
 
 # x-govuk components do not use ViewComponent previews
 ViewComponent/MissingPreview:

--- a/verification/polaris_rubocop_config.yml
+++ b/verification/polaris_rubocop_config.yml
@@ -1,10 +1,6 @@
-ViewComponent:
-  inherit_mode:
-    merge:
-      - ViewComponentParentClasses
-  ViewComponentParentClasses:
-    - Polaris::Component
-    - Component
+AllCops:
+  UseProjectIndex: true
+  ProjectIndexIncludesGems: true
 
 ViewComponent/MissingPreview:
   PreviewPaths:

--- a/verification/primer_rubocop_config.yml
+++ b/verification/primer_rubocop_config.yml
@@ -1,10 +1,6 @@
-ViewComponent:
-  inherit_mode:
-    merge:
-      - ViewComponentParentClasses
-  ViewComponentParentClasses:
-    - Primer::Component
-    - Primer::BaseComponent
+AllCops:
+  UseProjectIndex: true
+  ProjectIndexIncludesGems: true
 
 # Primer seems to intentionally omit the Component suffix from most class names
 # (116 out of 131 components), so this cop is not useful here.
@@ -31,3 +27,5 @@ ViewComponent/MissingPreview:
     - previews
   Exclude:
     - app/components/primer/base_component.rb
+    # Deprecated wrapper with no preview
+    - app/components/primer/navigation/tab_component.rb


### PR DESCRIPTION
Use rubydex for project-wide class ancestry resolution instead of requiring users to manually configure ViewComponentParentClasses.

- Add rubydex as a runtime dependency
- Bump minimum RuboCop to 1.89.0 (for project_index support)
- Update base.rb to use resolve_constant_in_index + has_ancestor?
- Remove ViewComponentParentClasses from config/default.yml
- Replace mock project index with real Rubydex::Graph in tests (LazyIndex wrapper for nesting resolution)
- Enable UseProjectIndex in verification configs
- Update README with rubydex requirement and link to blog post