### PR TITLE
Raise error when UseProjectIndex is not enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A RuboCop extension that encourages [ViewComponent best practices](https://viewc
 
 ## Installation
 
-This gem requires [rubydex](https://github.com/Shopify/rubydex) for project-wide class ancestry resolution. Add to your Gemfile:
+Add to your Gemfile:
 
 ```ruby
 gem 'rubocop-view_component', require: false
@@ -21,7 +21,9 @@ AllCops:
   ProjectIndexIncludesGems: true
 ```
 
-`ProjectIndexIncludesGems` is required so the cops can resolve ancestry chains that pass through gem classes (e.g. `ViewComponent::Base`). Without it, the cops cannot detect ViewComponent inheritance and fall back to conservative behavior.
+This gem makes use of [rubydex](https://github.com/Shopify/rubydex) to discover which classes inherit from `ViewComponent::Base`. Enable `ProjectIndexIncludesGems` so the cops can resolve ancestry chains that pass through gem classes.
+
+> **Note:** From v0.7.0 onwards, `UseProjectIndex: true` is required. Without it, cops that depend on ancestry detection will raise an error.
 
 For more background on how RuboCop uses rubydex for cross-file analysis, see [RuboCop 1.89: Project-Wide Analysis with Rubydex](https://metaredux.com/posts/2026/08/05/rubocop-1-89.html).
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ Add to your `.rubocop.yml`:
 ```yaml
 require:
   - rubocop-view_component
+```
+**Note:** From v0.7.0 onwards, this gem makes use of [rubydex](https://github.com/Shopify/rubydex) to discover which classes inherit from `ViewComponent::Base`. `UseProjectIndex` is required. Without it, cops that depend on ancestry detection will raise an error.
 
+```yaml
 AllCops:
   UseProjectIndex: true
-  ProjectIndexIncludesGems: true
 ```
 
-This gem makes use of [rubydex](https://github.com/Shopify/rubydex) to discover which classes inherit from `ViewComponent::Base`. Enable `ProjectIndexIncludesGems` so the cops can resolve ancestry chains that pass through gem classes.
-
-> **Note:** From v0.7.0 onwards, `UseProjectIndex: true` is required. Without it, cops that depend on ancestry detection will raise an error.
+If you use a ViewComponent library such as [primer](https://github.com/primer/view_components) then you'll also need to set `ProjectIndexIncludesGems: true` so the cops can resolve ancestry chains that pass through gem classes.
 
 For more background on how RuboCop uses rubydex for cross-file analysis, see [RuboCop 1.89: Project-Wide Analysis with Rubydex](https://metaredux.com/posts/2026/08/05/rubocop-1-89.html).
 

--- a/lib/rubocop/cop/view_component/base.rb
+++ b/lib/rubocop/cop/view_component/base.rb
@@ -19,6 +19,8 @@ module RuboCop
           class_source = fully_qualified_name(node)
           return true if component_namespaces.any? { |ns| class_source.start_with?(ns) }
 
+          require_project_index!
+
           parent_class = node.parent_class
           return false unless parent_class
 
@@ -28,7 +30,8 @@ module RuboCop
         # Check if a constant node resolves to a class with ViewComponent::Base as ancestor
         def view_component_parent?(node)
           return false unless node.const_type?
-          return false unless project_index
+
+          require_project_index!
 
           declaration = resolve_constant_in_index(node)
           return false unless declaration.respond_to?(:has_ancestor?)
@@ -40,7 +43,8 @@ module RuboCop
         # (has ViewComponent::Base as ancestor and has descendants in the project)
         def view_component_parent_class?(node)
           return false unless node&.class_type?
-          return false unless project_index
+
+          require_project_index!
 
           declaration = resolve_constant_in_index(node.identifier)
           return false unless declaration.respond_to?(:has_ancestor?)
@@ -68,10 +72,21 @@ module RuboCop
 
         # Check if node is within a ViewComponent class
         def inside_view_component?(node)
+          require_project_index!
+
           klass = enclosing_class(node)
           return false unless klass
 
           view_component_class?(klass)
+        end
+
+        def require_project_index!
+          return if project_index
+
+          raise <<~MSG
+            ViewComponent cops require `AllCops/UseProjectIndex: true` in your .rubocop.yml
+            for ancestry-based class detection.
+          MSG
         end
       end
     end

--- a/spec/rubocop/cop/view_component/base_spec.rb
+++ b/spec/rubocop/cop/view_component/base_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::ViewComponent::Base do
+  let(:cop_class) { RuboCop::Cop::ViewComponent::ComponentSuffix }
+  let(:cop) { cop_class.new(RuboCop::Config.new) }
+
+  before do
+    cop.project_index = nil
+  end
+
+  describe "#view_component_class?" do
+    it "raises when project_index is not set and class is not in ComponentNamespaces" do
+      source = parse_source(<<~RUBY)
+        class Foo < ViewComponent::Base
+        end
+      RUBY
+
+      expect { cop.send(:view_component_class?, source.ast) }.to raise_error(
+        RuntimeError,
+        /UseProjectIndex/
+      )
+    end
+
+    it "does not raise when class matches a ComponentNamespace" do
+      config = RuboCop::Config.new(
+        "ViewComponent/ComponentSuffix" => {
+          "ComponentNamespaces" => ["MyApp::"]
+        }
+      )
+      cop = cop_class.new(config)
+      cop.project_index = nil
+
+      source = parse_source(<<~RUBY)
+        module MyApp
+          class Foo < ViewComponent::Base
+          end
+        end
+      RUBY
+
+      class_node = source.ast.body
+
+      expect(cop.send(:view_component_class?, class_node)).to be true
+    end
+  end
+
+  describe "#view_component_parent?" do
+    it "raises when project_index is not set" do
+      source = parse_source(<<~RUBY)
+        class Foo < ViewComponent::Base
+        end
+      RUBY
+
+      parent = source.ast.parent_class
+
+      expect { cop.send(:view_component_parent?, parent) }.to raise_error(
+        RuntimeError,
+        /UseProjectIndex/
+      )
+    end
+  end
+
+  describe "#view_component_parent_class?" do
+    it "raises when project_index is not set" do
+      source = parse_source(<<~RUBY)
+        class Foo < ViewComponent::Base
+        end
+      RUBY
+
+      expect { cop.send(:view_component_parent_class?, source.ast) }.to raise_error(
+        RuntimeError,
+        /UseProjectIndex/
+      )
+    end
+  end
+
+  describe "#inside_view_component?" do
+    it "raises when project_index is not set" do
+      source = parse_source(<<~RUBY)
+        class Foo < ViewComponent::Base
+          def call; end
+        end
+      RUBY
+
+      method_node = source.ast.body
+
+      expect { cop.send(:inside_view_component?, method_node) }.to raise_error(
+        RuntimeError,
+        /UseProjectIndex/
+      )
+    end
+  end
+end


### PR DESCRIPTION
Previously, cops that depend on ancestry detection (ComponentSuffix, MissingPreview, PreferComposition, PreferSlots, PreferPrivateMethods, NoGlobalState) would silently skip classes when UseProjectIndex was not set. This made it easy to miss configuration issues.

Now these cops raise a clear error directing users to enable `AllCops/UseProjectIndex: true` in their `.rubocop.yml`.

## Changes

- Added `require_project_index!` guard to `Base` module detection methods
- Added specs verifying the error is raised when `project_index` is nil
- Updated README to note this requirement from v0.7.0