### PR TITLE
Fix TestRenderedOutput value object detection

### DIFF
--- a/lib/rubocop/cop/view_component/test_rendered_output.rb
+++ b/lib/rubocop/cop/view_component/test_rendered_output.rb
@@ -48,8 +48,8 @@ module RuboCop
 
           add_offense(node)
         end
-        alias_method :on_numblock, :on_block
-        alias_method :on_itblock, :on_block
+        alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/lib/rubocop/cop/view_component/test_rendered_output.rb
+++ b/lib/rubocop/cop/view_component/test_rendered_output.rb
@@ -22,6 +22,8 @@ module RuboCop
       #   end
       #
       class TestRenderedOutput < RuboCop::Cop::Base
+        include ViewComponent::Base
+
         MSG = "Test instantiates a component but doesn't use `render_inline` or `render_preview`. " \
               "Test the rendered output instead of component methods directly."
 
@@ -46,8 +48,8 @@ module RuboCop
 
           add_offense(node)
         end
-        alias on_numblock on_block
-        alias on_itblock on_block
+        alias_method :on_numblock, :on_block
+        alias_method :on_itblock, :on_block
 
         private
 
@@ -63,7 +65,8 @@ module RuboCop
           node.each_descendant(:send).any? do |send_node|
             next unless send_node.method?(:new)
 
-            send_node.receiver&.const_type?
+            receiver = send_node.receiver
+            receiver&.const_type? && view_component_parent?(receiver)
           end
         end
 

--- a/spec/rubocop/cop/view_component/test_rendered_output_spec.rb
+++ b/spec/rubocop/cop/view_component/test_rendered_output_spec.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::ViewComponent::TestRenderedOutput, :config do
+  include ViewComponent::ProjectIndexHelpers
+
   let(:config) { RuboCop::Config.new }
+  let(:project_index) { build_index }
 
   context "with Minitest-style tests" do
     context "when test instantiates a component but doesn't render" do
@@ -17,12 +20,32 @@ RSpec.describe RuboCop::Cop::ViewComponent::TestRenderedOutput, :config do
     end
 
     context "when test instantiates a non-Component-suffixed class" do
-      it "registers an offense" do
+      it "registers an offense for an indexed component" do
         expect_offense(<<~RUBY)
           def test_toggle
           ^^^^^^^^^^^^^^^ ViewComponent/TestRenderedOutput: Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly.
-            component = V2::Toggle.new
+            component = UserComponent.new
             assert component.active?
+          end
+        RUBY
+      end
+    end
+
+    context "when test instantiates a non-ViewComponent value object" do
+      let(:project_index) do
+        build_index(
+          "file:///month.rb" => <<~RUBY
+            class Month
+            end
+          RUBY
+        )
+      end
+
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          def test_month
+            month = Month.new
+            assert month.active?
           end
         RUBY
       end
@@ -84,11 +107,11 @@ RSpec.describe RuboCop::Cop::ViewComponent::TestRenderedOutput, :config do
     end
 
     context "when test instantiates a namespaced component" do
-      it "registers an offense" do
+      it "registers an offense for an indexed component" do
         expect_offense(<<~RUBY)
           def test_namespaced
           ^^^^^^^^^^^^^^^^^^^ ViewComponent/TestRenderedOutput: Test instantiates a component but doesn't use `render_inline` or `render_preview`. Test the rendered output instead of component methods directly.
-            component = Admin::UserComponent.new("hello")
+            component = UserComponent.new("hello")
             assert_equal "HELLO", component.formatted_title
           end
         RUBY
@@ -99,7 +122,7 @@ RSpec.describe RuboCop::Cop::ViewComponent::TestRenderedOutput, :config do
   context "with TestPaths configured" do
     let(:config) do
       RuboCop::Config.new(
-        "AllCops" => { "DisplayCopNames" => true },
+        "AllCops" => {"DisplayCopNames" => true},
         "ViewComponent/TestRenderedOutput" => {
           "TestPaths" => ["spec/components/v2/"]
         }

--- a/spec/rubocop/cop/view_component/test_rendered_output_spec.rb
+++ b/spec/rubocop/cop/view_component/test_rendered_output_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe RuboCop::Cop::ViewComponent::TestRenderedOutput, :config do
   context "with TestPaths configured" do
     let(:config) do
       RuboCop::Config.new(
-        "AllCops" => {"DisplayCopNames" => true},
+        "AllCops" => { "DisplayCopNames" => true },
         "ViewComponent/TestRenderedOutput" => {
           "TestPaths" => ["spec/components/v2/"]
         }


### PR DESCRIPTION
TestRenderedOutput now resolves instantiated constants through the project index and only flags ViewComponent descendants. Add regression coverage ensuring plain value objects are ignored while indexed components remain covered. Tests: bundle exec rspec.

Fixed #62 