### PR TITLE
Update RuboCop to 1.90.0

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 appraise "rubocop-minimum" do
-  gem "rubocop", "= 1.89.0"
+  gem "rubocop", "= 1.90.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       herb
       lint_roller (~> 1.1)
       parser
-      rubocop (>= 1.89.0)
+      rubocop (>= 1.90.0)
       rubydex
 
 GEM
@@ -91,8 +91,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    rubocop (1.89.0)
-      json (~> 2.3)
+    rubocop (1.90.0)
+      json (>= 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
       parallel (>= 1.10)

--- a/gemfiles/rubocop_minimum.gemfile
+++ b/gemfiles/rubocop_minimum.gemfile
@@ -6,7 +6,7 @@ gem "appraisal"
 gem "irb"
 gem "rake", "~> 13.4"
 gem "rspec"
-gem "rubocop", "= 1.89.0"
+gem "rubocop", "= 1.90.0"
 gem "rubocop-rake"
 gem "rubocop-rspec"
 

--- a/gemfiles/rubocop_minimum.gemfile.lock
+++ b/gemfiles/rubocop_minimum.gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: ..
   specs:
-    rubocop-view_component (0.6.0)
+    rubocop-view_component (0.7.0)
       activesupport
       herb
       lint_roller (~> 1.1)
       parser
-      rubocop (>= 1.89.0)
+      rubocop (>= 1.90.0)
       rubydex
 
 GEM
@@ -99,8 +99,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    rubocop (1.89.0)
-      json (~> 2.3)
+    rubocop (1.90.0)
+      json (>= 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
       parallel (>= 1.10)
@@ -153,7 +153,7 @@ DEPENDENCIES
   irb
   rake (~> 13.4)
   rspec
-  rubocop (= 1.89.0)
+  rubocop (= 1.90.0)
   rubocop-rake
   rubocop-rspec
   rubocop-view_component!

--- a/rubocop-view_component.gemspec
+++ b/rubocop-view_component.gemspec
@@ -41,6 +41,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "parser"
   spec.add_dependency "rubydex"
   # Keep in sync with the rubocop-minimum appraisal in Appraisals
-  # Requires 1.89+ for project_index support (rubydex integration)
-  spec.add_dependency "rubocop", ">= 1.89.0"
+  # Requires 1.90+ for project_index support (rubydex integration)
+  spec.add_dependency "rubocop", ">= 1.90.0"
 end

--- a/script/verify
+++ b/script/verify
@@ -123,6 +123,7 @@ def run_rubocop
     "--plugin", "rubocop-view_component",
     "--only", "ViewComponent",
     "--config", ".rubocop.yml",
+    "--report-unused-todo-entries",
     "--format", "json"
   )
 


### PR DESCRIPTION
Updates the minimum supported RuboCop version and lockfiles to 1.90.0. Adds the new --report-unused-todo-entries flag to verification runs. Tests pass: 87 RSpec examples, and RuboCop reports no offenses.